### PR TITLE
[UPD] ssi_school_scholarship - Tampilkan beasiswa pada school_student dan school_enrollment

### DIFF
--- a/ssi_school_scholarship/__manifest__.py
+++ b/ssi_school_scholarship/__manifest__.py
@@ -55,6 +55,8 @@
         "views/school_scholarship_program.xml",
         "views/school_scholarship_letter.xml",
         "views/school_scholarship_award.xml",
+        "views/school_student.xml",
+        "views/school_enrollment.xml",
         "views/assets.xml",
     ],
 }

--- a/ssi_school_scholarship/models/__init__.py
+++ b/ssi_school_scholarship/models/__init__.py
@@ -12,3 +12,5 @@ from . import school_scholarship_award_funding  # noqa: F401
 from . import school_scholarship_award_schedule  # noqa: F401
 from . import school_scholarship_letter  # noqa: F401
 from . import school_scholarship_award  # noqa: F401
+from . import school_student  # noqa: F401
+from . import school_enrollment  # noqa: F401

--- a/ssi_school_scholarship/models/school_enrollment.py
+++ b/ssi_school_scholarship/models/school_enrollment.py
@@ -1,0 +1,105 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models
+
+
+class SchoolEnrollment(models.Model):
+    """
+    Adds scholarship visibility to the enrollment record.
+    Exposes the committed scholarship amount and the awards linked to
+    this enrollment so billing staff can see the discount that
+    applies to it. This is a commitment figure only: it never touches
+    ``school_enrollment_payment_term`` or its detail lines, which
+    stay the source of the actual billed/realized amounts -- keeping
+    the two journals cleanly separated.
+    """
+
+    _name = "school_enrollment"
+    _inherit = [
+        "school_enrollment",
+    ]
+
+    scholarship_award_ids = fields.One2many(
+        string="Scholarship Awards",
+        comodel_name="school_scholarship_award",
+        inverse_name="enrollment_id",
+        help="Scholarship awards linked to this enrollment.",
+    )
+    amount_scholarship = fields.Monetary(
+        string="Scholarship Amount",
+        compute="_compute_amount_scholarship",
+        store=True,
+        compute_sudo=True,
+        currency_field="currency_id",
+        groups="ssi_school_scholarship.school_scholarship_award_viewer_group",
+        help=(
+            "Total amount awarded by this enrollment's Open or Done "
+            "scholarship awards. A commitment figure, not a "
+            "realization -- realization becomes available once the "
+            "deduction module ships. Restricted to the Scholarship "
+            "Award Viewer group."
+        ),
+    )
+    scholarship_award_count = fields.Integer(
+        string="Scholarship Award Count",
+        compute="_compute_scholarship_award_count",
+        store=False,
+        compute_sudo=True,
+        help="Number of scholarship awards linked to this enrollment.",
+    )
+
+    @api.depends(
+        "scholarship_award_ids.state",
+        "scholarship_award_ids.amount_awarded",
+    )
+    def _compute_amount_scholarship(self):
+        """Sum the awarded amount of Open or Done scholarship awards.
+
+        :return: nothing; assigns ``amount_scholarship``
+        """
+        for record in self:
+            result = 0.0
+            awards = record.scholarship_award_ids.filtered(
+                lambda award: award.state in ("open", "done")
+            )
+            if awards:
+                result = sum(awards.mapped("amount_awarded"))
+            record.amount_scholarship = result
+
+    @api.depends("scholarship_award_ids")
+    def _compute_scholarship_award_count(self):
+        """Count the scholarship awards linked to this enrollment.
+
+        :return: nothing; assigns ``scholarship_award_count``
+        """
+        for record in self:
+            record.scholarship_award_count = len(record.scholarship_award_ids)
+
+    def action_open_scholarship_award(self):
+        """Open the list of scholarship awards linked to this enrollment.
+
+        :return: an ``ir.actions.act_window`` dict
+        """
+        for record in self.sudo():
+            result = record._open_scholarship_award()
+        return result
+
+    def _open_scholarship_award(self):
+        """Build the window action listing this enrollment's awards.
+
+        :return: an ``ir.actions.act_window`` dict limited to the
+            scholarship awards of this enrollment
+        """
+        self.ensure_one()
+        waction = self.env.ref(
+            "ssi_school_scholarship.school_scholarship_award_action"
+        ).read()[0]
+        waction.update(
+            {
+                "domain": [("enrollment_id", "=", self.id)],
+                "context": {"default_enrollment_id": self.id},
+            }
+        )
+        return waction

--- a/ssi_school_scholarship/models/school_student.py
+++ b/ssi_school_scholarship/models/school_student.py
@@ -1,0 +1,145 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models
+
+
+class SchoolStudent(models.Model):
+    """
+    Adds scholarship visibility to the student card.
+    Exposes the scholarship awards granted to a student together with
+    two confidentiality-gated indicators -- whether the student
+    currently holds a scholarship, and which award (if any) is in
+    effect today -- so front office staff can tell a scholarship
+    recipient apart from a regular student without opening the
+    Scholarship app themselves.
+    """
+
+    _name = "school_student"
+    _inherit = [
+        "school_student",
+    ]
+
+    scholarship_award_ids = fields.One2many(
+        string="Scholarship Awards",
+        comodel_name="school_scholarship_award",
+        inverse_name="student_id",
+        help="Scholarship awards granted to this student.",
+    )
+    active_award_id = fields.Many2one(
+        string="Active Scholarship Award",
+        comodel_name="school_scholarship_award",
+        compute="_compute_active_award_id",
+        store=False,
+        compute_sudo=True,
+        groups="ssi_school_scholarship.school_scholarship_award_viewer_group",
+        help=(
+            "Open award whose period covers today, i.e. the "
+            "scholarship currently in effect for this student. "
+            "Restricted to the Scholarship Award Viewer group -- "
+            "confidential, must not leak through export or reports."
+        ),
+    )
+    has_scholarship = fields.Boolean(
+        string="Has Scholarship",
+        compute="_compute_has_scholarship",
+        store=True,
+        compute_sudo=True,
+        groups="ssi_school_scholarship.school_scholarship_award_viewer_group",
+        help=(
+            "True when this student has at least one Open or Done "
+            "scholarship award. Restricted to the Scholarship Award "
+            "Viewer group -- must never be shown on the general "
+            "student tree view or on class reports."
+        ),
+    )
+    scholarship_award_count = fields.Integer(
+        string="Scholarship Award Count",
+        compute="_compute_scholarship_award_count",
+        store=False,
+        compute_sudo=True,
+        help="Number of scholarship awards granted to this student.",
+    )
+
+    @api.depends(
+        "scholarship_award_ids.state",
+        "scholarship_award_ids.date_start",
+        "scholarship_award_ids.date_end",
+    )
+    def _compute_active_award_id(self):
+        """Resolve the Open award whose period covers today.
+
+        Reads ``fields.Date.context_today`` at compute time, so the
+        result moves with the calendar even when nothing on this
+        record has changed -- the field is therefore ``store=False``
+        despite declaring real field dependencies above. When more
+        than one award qualifies, the one with the latest
+        ``date_start`` wins.
+
+        :return: nothing; assigns ``active_award_id``
+        """
+        today = fields.Date.context_today(self)
+        for record in self:
+            result = False
+            candidates = record.scholarship_award_ids.filtered(
+                lambda award: award.state == "open"
+                and award.date_start
+                and award.date_end
+                and award.date_start <= today <= award.date_end
+            )
+            if candidates:
+                result = candidates.sorted(
+                    key=lambda award: award.date_start, reverse=True
+                )[0]
+            record.active_award_id = result
+
+    @api.depends("scholarship_award_ids.state")
+    def _compute_has_scholarship(self):
+        """Flag students holding an Open or Done scholarship award.
+
+        :return: nothing; assigns ``has_scholarship``
+        """
+        for record in self:
+            result = False
+            if record.scholarship_award_ids.filtered(
+                lambda award: award.state in ("open", "done")
+            ):
+                result = True
+            record.has_scholarship = result
+
+    @api.depends("scholarship_award_ids")
+    def _compute_scholarship_award_count(self):
+        """Count the scholarship awards granted to this student.
+
+        :return: nothing; assigns ``scholarship_award_count``
+        """
+        for record in self:
+            record.scholarship_award_count = len(record.scholarship_award_ids)
+
+    def action_open_scholarship_award(self):
+        """Open the list of scholarship awards granted to this student.
+
+        :return: an ``ir.actions.act_window`` dict
+        """
+        for record in self.sudo():
+            result = record._open_scholarship_award()
+        return result
+
+    def _open_scholarship_award(self):
+        """Build the window action listing this student's awards.
+
+        :return: an ``ir.actions.act_window`` dict limited to the
+            scholarship awards of this student
+        """
+        self.ensure_one()
+        waction = self.env.ref(
+            "ssi_school_scholarship.school_scholarship_award_action"
+        ).read()[0]
+        waction.update(
+            {
+                "domain": [("student_id", "=", self.id)],
+                "context": {"default_student_id": self.id},
+            }
+        )
+        return waction

--- a/ssi_school_scholarship/tests/__init__.py
+++ b/ssi_school_scholarship/tests/__init__.py
@@ -13,3 +13,5 @@ from . import test_school_scholarship_criteria
 from . import test_school_scholarship_award
 from . import test_school_scholarship_award_schedule
 from . import test_ui_school_scholarship_award
+from . import test_school_student
+from . import test_school_enrollment

--- a/ssi_school_scholarship/tests/test_data_school_enrollment.yaml
+++ b/ssi_school_scholarship/tests/test_data_school_enrollment.yaml
@@ -133,6 +133,14 @@ scenarios:
           funding_source_ids: [[6, 0, ["REC: funding_source_se.id"]]]
           deduction_journal_id: "REC: journal_se.id"
           discount_account_id: "REC: discount_account_se.id"
+          scope_ids:
+            - - 0
+              - 0
+              - scope_basis: "product"
+                product_id: "REC: product_se.id"
+                benefit_type: "fee_reduction"
+                computation: "percentage"
+                percentage: 40.0
 
       - step: "Create the student contact"
         action: "create"

--- a/ssi_school_scholarship/tests/test_data_school_enrollment.yaml
+++ b/ssi_school_scholarship/tests/test_data_school_enrollment.yaml
@@ -1,0 +1,278 @@
+options:
+  auto_refresh: true
+
+scenarios:
+  - name: "Enrollment - Scholarship Amount"
+    steps:
+      # ── Shared fixture chain (suffix SE) ─────────────────────────
+      - step: "Create the grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type_se"
+        values:
+          name: "SE Grade Type"
+          code: "SEGT"
+
+      - step: "Create the school"
+        action: "create"
+        model: "school"
+        save_as: "school_se"
+        values:
+          name: "SE School"
+          code: "SESC"
+          grade_type_id: "REC: grade_type_se.id"
+
+      - step: "Create the academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year_se"
+        values:
+          name: "SE Academic Year"
+          code: "SEAY"
+          date_start: 2026-07-01
+          date_end: 2027-06-30
+
+      - step: "Create the academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term_se"
+        values:
+          name: "SE Term"
+          code: "SETM"
+          date_start: 2026-07-01
+          date_end: 2026-12-31
+          year_id: "REC: academic_year_se.id"
+
+      - step: "Create the grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade_se"
+        values:
+          name: "SE Grade"
+          code: "SEGR"
+          type_id: "REC: grade_type_se.id"
+
+      - step: "Create the grade class"
+        action: "create"
+        model: "school_grade_class"
+        save_as: "grade_class_se"
+        values:
+          name: "SE Class"
+          code: "SECL"
+          school_id: "REC: school_se.id"
+          grade_id: "REC: grade_se.id"
+
+      - step: "Create the analytic account for the funding source"
+        action: "create"
+        model: "account.analytic.account"
+        save_as: "analytic_se"
+        values:
+          name: "SE Analytic"
+
+      - step: "Create the funding source"
+        action: "create"
+        model: "school_scholarship_funding_source"
+        save_as: "funding_source_se"
+        values:
+          name: "SE Funding Source"
+          code: "SEFS"
+          analytic_account_id: "REC: analytic_se.id"
+
+      - step: "Create the product covered by the benefit lines"
+        action: "create"
+        model: "product.product"
+        save_as: "product_se"
+        values:
+          name: "SE Product"
+          type: "service"
+
+      - step: "Create the sale journal used by the scholarship type"
+        action: "create"
+        model: "account.journal"
+        save_as: "journal_se"
+        values:
+          name: "SE Journal"
+          code: "JSE"
+          type: "sale"
+
+      - step: "Get the account.account.type Income reference"
+        action: "ref"
+        xml_id: "account.data_account_type_revenue"
+        save_as: "account_type_income"
+
+      - step: "Create the discount account"
+        action: "create"
+        model: "account.account"
+        save_as: "discount_account_se"
+        values:
+          name: "SE Discount Account"
+          code: "SEDA"
+          user_type_id: "REC: account_type_income.id"
+          reconcile: false
+
+      - step: "Create the scholarship type"
+        action: "create"
+        model: "school_scholarship_type"
+        save_as: "type_se"
+        values:
+          name: "SE Type"
+          code: "SETY"
+          deduction_journal_id: "REC: journal_se.id"
+          discount_account_id: "REC: discount_account_se.id"
+
+      - step: "Create the scholarship program"
+        action: "create"
+        model: "school_scholarship_program"
+        save_as: "program_se"
+        values:
+          name: "SE Program"
+          code: "SEPRG"
+          type_id: "REC: type_se.id"
+          school_id: "REC: school_se.id"
+          academic_year_id: "REC: academic_year_se.id"
+          funding_source_ids: [[6, 0, ["REC: funding_source_se.id"]]]
+          deduction_journal_id: "REC: journal_se.id"
+          discount_account_id: "REC: discount_account_se.id"
+
+      - step: "Create the student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "contact_se"
+        values:
+          name: "SE Contact"
+
+      - step: "Create the student"
+        action: "create"
+        model: "school_student"
+        save_as: "student_se"
+        values:
+          name: "SE Student"
+          code: "SEST"
+          contact_id: "REC: contact_se.id"
+          school_id: "REC: school_se.id"
+
+      - step: "Create the enrollment"
+        action: "create"
+        model: "school_enrollment"
+        save_as: "enrollment_se"
+        values:
+          academic_year_id: "REC: academic_year_se.id"
+          academic_term_id: "REC: academic_term_se.id"
+          school_id: "REC: school_se.id"
+          grade_id: "REC: grade_se.id"
+          grade_class_id: "REC: grade_class_se.id"
+          student_id: "REC: student_se.id"
+
+      # ── Positive (compute): two Open awards on the same enrollment,
+      # 400,000 and 600,000, must sum to 1,000,000. Each Benefit line
+      # is Cash/Fixed, so its Amount Planned equals its Fixed Amount
+      # directly and needs no Payment Term to realize a Schedule line.
+      - step: "Create the first award (400,000)"
+        action: "create"
+        model: "school_scholarship_award"
+        save_as: "award_se1"
+        values:
+          program_id: "REC: program_se.id"
+          student_id: "REC: student_se.id"
+          enrollment_id: "REC: enrollment_se.id"
+          date_start: 2026-08-07
+          date_end: 2027-08-09
+          # Owned by admin so the ``as_user: base.user_admin`` steps
+          # below are not rejected by the internal_user_rule record
+          # rule (odoo-development-unit-test test-traps.md T-05).
+          user_id: "REF: base.user_admin"
+          benefit_ids:
+            - - 0
+              - 0
+              - name: "SE Benefit 1"
+                benefit_type: "cash"
+                computation: "fixed"
+                amount_fixed: 400000.0
+                product_id: "REC: product_se.id"
+
+      - step: "Confirm the first award as admin"
+        action: "call"
+        target: "award_se1"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
+
+      - step: "Approve the first award as admin"
+        action: "call"
+        target: "award_se1"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+      - step: "Assert the first award was awarded 400,000"
+        action: "assert"
+        target: "award_se1"
+        asserts:
+          amount_awarded:
+            type: "value"
+            expected: 400000.0
+
+      - step: "Create the second award (600,000)"
+        action: "create"
+        model: "school_scholarship_award"
+        save_as: "award_se2"
+        values:
+          program_id: "REC: program_se.id"
+          student_id: "REC: student_se.id"
+          enrollment_id: "REC: enrollment_se.id"
+          date_start: 2026-08-07
+          date_end: 2027-08-09
+          user_id: "REF: base.user_admin"
+          benefit_ids:
+            - - 0
+              - 0
+              - name: "SE Benefit 2"
+                benefit_type: "cash"
+                computation: "fixed"
+                amount_fixed: 600000.0
+                product_id: "REC: product_se.id"
+
+      - step: "Confirm the second award as admin"
+        action: "call"
+        target: "award_se2"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
+
+      - step: "Approve the second award as admin"
+        action: "call"
+        target: "award_se2"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+      - step: "Assert the second award was awarded 600,000"
+        action: "assert"
+        target: "award_se2"
+        asserts:
+          amount_awarded:
+            type: "value"
+            expected: 600000.0
+
+      - step: "Assert the enrollment sums both awards' committed amount"
+        action: "assert"
+        target: "enrollment_se"
+        asserts:
+          amount_scholarship:
+            type: "value"
+            expected: 1000000.0
+          scholarship_award_count:
+            type: "value"
+            expected: 2

--- a/ssi_school_scholarship/tests/test_data_school_student.yaml
+++ b/ssi_school_scholarship/tests/test_data_school_student.yaml
@@ -133,6 +133,14 @@ scenarios:
           funding_source_ids: [[6, 0, ["REC: funding_source_sv.id"]]]
           deduction_journal_id: "REC: journal_sv.id"
           discount_account_id: "REC: discount_account_sv.id"
+          scope_ids:
+            - - 0
+              - 0
+              - scope_basis: "product"
+                product_id: "REC: product_sv.id"
+                benefit_type: "fee_reduction"
+                computation: "percentage"
+                percentage: 40.0
 
       # ── Positive (compute, empty condition): Student A has no
       # scholarship award at all.

--- a/ssi_school_scholarship/tests/test_data_school_student.yaml
+++ b/ssi_school_scholarship/tests/test_data_school_student.yaml
@@ -1,0 +1,427 @@
+options:
+  auto_refresh: true
+
+scenarios:
+  - name: "Student - Scholarship Visibility"
+    steps:
+      # ── Shared fixture chain (suffix SV) ─────────────────────────
+      - step: "Create the grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type_sv"
+        values:
+          name: "SV Grade Type"
+          code: "SVGT"
+
+      - step: "Create the school"
+        action: "create"
+        model: "school"
+        save_as: "school_sv"
+        values:
+          name: "SV School"
+          code: "SVSC"
+          grade_type_id: "REC: grade_type_sv.id"
+
+      - step: "Create the academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year_sv"
+        values:
+          name: "SV Academic Year"
+          code: "SVAY"
+          date_start: 2026-07-01
+          date_end: 2027-06-30
+
+      - step: "Create the academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term_sv"
+        values:
+          name: "SV Term"
+          code: "SVTM"
+          date_start: 2026-07-01
+          date_end: 2026-12-31
+          year_id: "REC: academic_year_sv.id"
+
+      - step: "Create the grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade_sv"
+        values:
+          name: "SV Grade"
+          code: "SVGR"
+          type_id: "REC: grade_type_sv.id"
+
+      - step: "Create the grade class"
+        action: "create"
+        model: "school_grade_class"
+        save_as: "grade_class_sv"
+        values:
+          name: "SV Class"
+          code: "SVCL"
+          school_id: "REC: school_sv.id"
+          grade_id: "REC: grade_sv.id"
+
+      - step: "Create the analytic account for the funding source"
+        action: "create"
+        model: "account.analytic.account"
+        save_as: "analytic_sv"
+        values:
+          name: "SV Analytic"
+
+      - step: "Create the funding source"
+        action: "create"
+        model: "school_scholarship_funding_source"
+        save_as: "funding_source_sv"
+        values:
+          name: "SV Funding Source"
+          code: "SVFS"
+          analytic_account_id: "REC: analytic_sv.id"
+
+      - step: "Create the product covered by the benefit line"
+        action: "create"
+        model: "product.product"
+        save_as: "product_sv"
+        values:
+          name: "SV Product"
+          type: "service"
+
+      - step: "Create the sale journal used by the scholarship type"
+        action: "create"
+        model: "account.journal"
+        save_as: "journal_sv"
+        values:
+          name: "SV Journal"
+          code: "JSV"
+          type: "sale"
+
+      - step: "Get the account.account.type Income reference"
+        action: "ref"
+        xml_id: "account.data_account_type_revenue"
+        save_as: "account_type_income"
+
+      - step: "Create the discount account"
+        action: "create"
+        model: "account.account"
+        save_as: "discount_account_sv"
+        values:
+          name: "SV Discount Account"
+          code: "SVDA"
+          user_type_id: "REC: account_type_income.id"
+          reconcile: false
+
+      - step: "Create the scholarship type"
+        action: "create"
+        model: "school_scholarship_type"
+        save_as: "type_sv"
+        values:
+          name: "SV Type"
+          code: "SVTY"
+          deduction_journal_id: "REC: journal_sv.id"
+          discount_account_id: "REC: discount_account_sv.id"
+
+      - step: "Create the scholarship program"
+        action: "create"
+        model: "school_scholarship_program"
+        save_as: "program_sv"
+        values:
+          name: "SV Program"
+          code: "SVPRG"
+          type_id: "REC: type_sv.id"
+          school_id: "REC: school_sv.id"
+          academic_year_id: "REC: academic_year_sv.id"
+          funding_source_ids: [[6, 0, ["REC: funding_source_sv.id"]]]
+          deduction_journal_id: "REC: journal_sv.id"
+          discount_account_id: "REC: discount_account_sv.id"
+
+      # ── Positive (compute, empty condition): Student A has no
+      # scholarship award at all.
+      - step: "Create Student A's contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "contact_sva"
+        values:
+          name: "SV Contact A"
+
+      - step: "Create Student A"
+        action: "create"
+        model: "school_student"
+        save_as: "student_sva"
+        values:
+          name: "SV Student A"
+          code: "SVSA"
+          contact_id: "REC: contact_sva.id"
+          school_id: "REC: school_sv.id"
+
+      - step: "Create Student A's enrollment"
+        action: "create"
+        model: "school_enrollment"
+        save_as: "enrollment_sva"
+        values:
+          academic_year_id: "REC: academic_year_sv.id"
+          academic_term_id: "REC: academic_term_sv.id"
+          school_id: "REC: school_sv.id"
+          grade_id: "REC: grade_sv.id"
+          grade_class_id: "REC: grade_class_sv.id"
+          student_id: "REC: student_sva.id"
+
+      - step: "Assert Student A has no scholarship"
+        action: "assert"
+        target: "student_sva"
+        asserts:
+          has_scholarship:
+            type: "value"
+            expected: false
+          scholarship_award_count:
+            type: "value"
+            expected: 0
+          active_award_id:
+            type: "value"
+            operator: "is_falsy"
+
+      - step: "Assert Student A's enrollment has no scholarship amount either"
+        action: "assert"
+        target: "enrollment_sva"
+        asserts:
+          amount_scholarship:
+            type: "value"
+            expected: 0.0
+          scholarship_award_count:
+            type: "value"
+            expected: 0
+
+      # ── Positive (compute): Student B has one Open award whose
+      # period covers today -> has_scholarship true, count 1, and
+      # active_award_id points to it. Dates are fixed, at least two
+      # days away from the authoring date, to avoid flakiness from
+      # the demo data's Europe/Brussels ``context_today`` (see
+      # odoo-development-unit-test test-traps.md T-02).
+      - step: "Create Student B's contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "contact_svb"
+        values:
+          name: "SV Contact B"
+
+      - step: "Create Student B"
+        action: "create"
+        model: "school_student"
+        save_as: "student_svb"
+        values:
+          name: "SV Student B"
+          code: "SVSB"
+          contact_id: "REC: contact_svb.id"
+          school_id: "REC: school_sv.id"
+
+      - step: "Create Student B's enrollment"
+        action: "create"
+        model: "school_enrollment"
+        save_as: "enrollment_svb"
+        values:
+          academic_year_id: "REC: academic_year_sv.id"
+          academic_term_id: "REC: academic_term_sv.id"
+          school_id: "REC: school_sv.id"
+          grade_id: "REC: grade_sv.id"
+          grade_class_id: "REC: grade_class_sv.id"
+          student_id: "REC: student_svb.id"
+
+      - step: "Create Student B's award, active today"
+        action: "create"
+        model: "school_scholarship_award"
+        save_as: "award_svb"
+        values:
+          program_id: "REC: program_sv.id"
+          student_id: "REC: student_svb.id"
+          enrollment_id: "REC: enrollment_svb.id"
+          date_start: 2026-08-07
+          date_end: 2027-08-09
+          # Owned by admin so the ``as_user: base.user_admin`` steps
+          # below are not rejected by the internal_user_rule record
+          # rule (odoo-development-unit-test test-traps.md T-05).
+          user_id: "REF: base.user_admin"
+          benefit_ids:
+            - - 0
+              - 0
+              - name: "SV Benefit B"
+                benefit_type: "cash"
+                computation: "fixed"
+                amount_fixed: 0.0
+                product_id: "REC: product_sv.id"
+
+      - step: "Confirm Student B's award as admin"
+        action: "call"
+        target: "award_svb"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
+
+      - step: "Approve Student B's award as admin"
+        action: "call"
+        target: "award_svb"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+      - step: "Assert Student B has an active scholarship"
+        action: "assert"
+        target: "student_svb"
+        asserts:
+          has_scholarship:
+            type: "value"
+            expected: true
+          scholarship_award_count:
+            type: "value"
+            expected: 1
+          active_award_id:
+            type: "m2o"
+            expected: "REC: award_svb"
+
+      # ── Positive (compute): Student C has an award, but it stays
+      # in Draft -- only Open/Done are counted by has_scholarship.
+      - step: "Create Student C's contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "contact_svc"
+        values:
+          name: "SV Contact C"
+
+      - step: "Create Student C"
+        action: "create"
+        model: "school_student"
+        save_as: "student_svc"
+        values:
+          name: "SV Student C"
+          code: "SVSC2"
+          contact_id: "REC: contact_svc.id"
+          school_id: "REC: school_sv.id"
+
+      - step: "Create Student C's enrollment"
+        action: "create"
+        model: "school_enrollment"
+        save_as: "enrollment_svc"
+        values:
+          academic_year_id: "REC: academic_year_sv.id"
+          academic_term_id: "REC: academic_term_sv.id"
+          school_id: "REC: school_sv.id"
+          grade_id: "REC: grade_sv.id"
+          grade_class_id: "REC: grade_class_sv.id"
+          student_id: "REC: student_svc.id"
+
+      - step: "Create Student C's award, left in Draft"
+        action: "create"
+        model: "school_scholarship_award"
+        save_as: "award_svc"
+        values:
+          program_id: "REC: program_sv.id"
+          student_id: "REC: student_svc.id"
+          enrollment_id: "REC: enrollment_svc.id"
+          date_start: 2026-08-07
+          date_end: 2027-08-09
+          benefit_ids:
+            - - 0
+              - 0
+              - name: "SV Benefit C"
+                benefit_type: "cash"
+                computation: "fixed"
+                amount_fixed: 0.0
+                product_id: "REC: product_sv.id"
+
+      - step: "Assert Student C's Draft award does not count as a scholarship"
+        action: "assert"
+        target: "student_svc"
+        asserts:
+          has_scholarship:
+            type: "value"
+            expected: false
+          scholarship_award_count:
+            type: "value"
+            expected: 1
+
+      # ── Positive (compute): Student E has an Open award whose
+      # period has already lapsed -> active_award_id stays empty,
+      # even though has_scholarship is still true.
+      - step: "Create Student E's contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "contact_sve"
+        values:
+          name: "SV Contact E"
+
+      - step: "Create Student E"
+        action: "create"
+        model: "school_student"
+        save_as: "student_sve"
+        values:
+          name: "SV Student E"
+          code: "SVSE"
+          contact_id: "REC: contact_sve.id"
+          school_id: "REC: school_sv.id"
+
+      - step: "Create Student E's enrollment"
+        action: "create"
+        model: "school_enrollment"
+        save_as: "enrollment_sve"
+        values:
+          academic_year_id: "REC: academic_year_sv.id"
+          academic_term_id: "REC: academic_term_sv.id"
+          school_id: "REC: school_sv.id"
+          grade_id: "REC: grade_sv.id"
+          grade_class_id: "REC: grade_class_sv.id"
+          student_id: "REC: student_sve.id"
+
+      - step: "Create Student E's award, whose period has lapsed"
+        action: "create"
+        model: "school_scholarship_award"
+        save_as: "award_sve"
+        values:
+          program_id: "REC: program_sv.id"
+          student_id: "REC: student_sve.id"
+          enrollment_id: "REC: enrollment_sve.id"
+          date_start: 2025-01-01
+          date_end: 2025-06-30
+          user_id: "REF: base.user_admin"
+          benefit_ids:
+            - - 0
+              - 0
+              - name: "SV Benefit E"
+                benefit_type: "cash"
+                computation: "fixed"
+                amount_fixed: 0.0
+                product_id: "REC: product_sv.id"
+
+      - step: "Confirm Student E's award as admin"
+        action: "call"
+        target: "award_sve"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
+
+      - step: "Approve Student E's award as admin"
+        action: "call"
+        target: "award_sve"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+      - step: "Assert Student E's active award is empty despite having a scholarship"
+        action: "assert"
+        target: "student_sve"
+        asserts:
+          has_scholarship:
+            type: "value"
+            expected: true
+          active_award_id:
+            type: "value"
+            operator: "is_falsy"

--- a/ssi_school_scholarship/tests/test_school_enrollment.py
+++ b/ssi_school_scholarship/tests/test_school_enrollment.py
@@ -1,0 +1,96 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestSchoolEnrollment(YamlTransactionCase):
+    """Scenario tests for the scholarship fields glued onto
+    ``school_enrollment``.
+    """
+
+    def test_school_enrollment_scholarship(self):
+        """Run the scholarship amount compute scenario."""
+        self.run_yaml_scenario("test_data_school_enrollment.yaml")
+
+    def test_open_scholarship_award_action(self):
+        """The smart button returns an act_window scoped to this
+        enrollment.
+
+        P1, L-01/L-02: ``action: call`` discards the method's return
+        value and the YAML ``assert`` action's *actual* side is
+        always a dotted ``getattr`` on a record, so the returned
+        ``ir.actions.act_window`` dict has to be inspected here, in
+        plain Python.
+        """
+        grade_type = self.env["school_grade_type"].create(
+            {
+                "name": "P1 Grade Type",
+                "code": "/",
+            }
+        )
+        school = self.env["school"].create(
+            {
+                "name": "P1 School",
+                "code": "/",
+                "grade_type_id": grade_type.id,
+            }
+        )
+        academic_year = self.env["school_academic_year"].create(
+            {
+                "name": "P1 Academic Year",
+                "code": "/",
+                "date_start": "2026-07-01",
+                "date_end": "2027-06-30",
+            }
+        )
+        academic_term = self.env["school_academic_term"].create(
+            {
+                "name": "P1 Term",
+                "code": "/",
+                "date_start": "2026-07-01",
+                "date_end": "2026-12-31",
+                "year_id": academic_year.id,
+            }
+        )
+        grade = self.env["school_grade"].create(
+            {
+                "name": "P1 Grade",
+                "code": "/",
+                "type_id": grade_type.id,
+            }
+        )
+        grade_class = self.env["school_grade_class"].create(
+            {
+                "name": "P1 Class",
+                "code": "/",
+                "school_id": school.id,
+                "grade_id": grade.id,
+            }
+        )
+        contact = self.env["res.partner"].create({"name": "P1 Contact"})
+        student = self.env["school_student"].create(
+            {
+                "name": "P1 Student",
+                "code": "/",
+                "contact_id": contact.id,
+                "school_id": school.id,
+            }
+        )
+        enrollment = self.env["school_enrollment"].create(
+            {
+                "academic_year_id": academic_year.id,
+                "academic_term_id": academic_term.id,
+                "school_id": school.id,
+                "grade_id": grade.id,
+                "grade_class_id": grade_class.id,
+                "student_id": student.id,
+            }
+        )
+        action = enrollment.action_open_scholarship_award()
+        self.assertEqual(action["res_model"], "school_scholarship_award")
+        self.assertEqual(action["domain"], [("enrollment_id", "=", enrollment.id)])

--- a/ssi_school_scholarship/tests/test_school_student.py
+++ b/ssi_school_scholarship/tests/test_school_student.py
@@ -1,0 +1,53 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestSchoolStudent(YamlTransactionCase):
+    """Scenario tests for the scholarship fields glued onto
+    ``school_student``.
+    """
+
+    def test_school_student_scholarship(self):
+        """Run the scholarship visibility compute scenarios."""
+        self.run_yaml_scenario("test_data_school_student.yaml")
+
+    def test_open_scholarship_award_action(self):
+        """The smart button returns an act_window scoped to this student.
+
+        P1, L-01/L-02: ``action: call`` discards the method's return
+        value and the YAML ``assert`` action's *actual* side is
+        always a dotted ``getattr`` on a record, so the returned
+        ``ir.actions.act_window`` dict has to be inspected here, in
+        plain Python.
+        """
+        grade_type = self.env["school_grade_type"].create(
+            {
+                "name": "P1 Grade Type",
+                "code": "/",
+            }
+        )
+        school = self.env["school"].create(
+            {
+                "name": "P1 School",
+                "code": "/",
+                "grade_type_id": grade_type.id,
+            }
+        )
+        contact = self.env["res.partner"].create({"name": "P1 Contact"})
+        student = self.env["school_student"].create(
+            {
+                "name": "P1 Student",
+                "code": "/",
+                "contact_id": contact.id,
+                "school_id": school.id,
+            }
+        )
+        action = student.action_open_scholarship_award()
+        self.assertEqual(action["res_model"], "school_scholarship_award")
+        self.assertEqual(action["domain"], [("student_id", "=", student.id)])

--- a/ssi_school_scholarship/views/school_enrollment.xml
+++ b/ssi_school_scholarship/views/school_enrollment.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+<record id="school_enrollment_view_form" model="ir.ui.view">
+    <field name="name">school scholarship - school_enrollment - form</field>
+    <field name="model">school_enrollment</field>
+    <field name="inherit_id" ref="ssi_school.school_enrollment_view_form" />
+    <field name="arch" type="xml">
+        <data>
+            <xpath expr="//div[hasclass('oe_button_box')]" position="inside">
+                <button
+                        name="action_open_scholarship_award"
+                        type="object"
+                        class="oe_stat_button"
+                        icon="fa-graduation-cap"
+                    >
+                    <field
+                            name="scholarship_award_count"
+                            string="Awards"
+                            widget="statinfo"
+                        />
+                </button>
+            </xpath>
+            <xpath expr="//group[@name='header_right']" position="inside">
+                <field name="amount_scholarship" />
+            </xpath>
+        </data>
+    </field>
+</record>
+</odoo>

--- a/ssi_school_scholarship/views/school_student.xml
+++ b/ssi_school_scholarship/views/school_student.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+<record id="school_student_view_form" model="ir.ui.view">
+    <field name="name">school scholarship - school_student - form</field>
+    <field name="model">school_student</field>
+    <field name="inherit_id" ref="ssi_school.school_student_view_form" />
+    <field name="arch" type="xml">
+        <data>
+            <xpath expr="//div[hasclass('oe_button_box')]" position="inside">
+                <button
+                        name="action_open_scholarship_award"
+                        type="object"
+                        class="oe_stat_button"
+                        icon="fa-graduation-cap"
+                    >
+                    <field
+                            name="scholarship_award_count"
+                            string="Awards"
+                            widget="statinfo"
+                        />
+                </button>
+            </xpath>
+        </data>
+    </field>
+</record>
+</odoo>


### PR DESCRIPTION
## Ringkasan

- Tambah field beasiswa pada `school_student` (`scholarship_award_ids`, `active_award_id`, `has_scholarship`, `scholarship_award_count`) dan `school_enrollment` (`scholarship_award_ids`, `amount_scholarship`, `scholarship_award_count`) lewat glue module `_name` + `_inherit`.
- Tambah smart button pada form `school_student` dan `school_enrollment` yang membuka daftar award ter-filter milik record itu.
- Batasi akses baca `has_scholarship`, `active_award_id`, dan `amount_scholarship` ke grup `ssi_school_scholarship.school_scholarship_award_viewer_group` agar data penerima beasiswa tetap rahasia.
- `school_enrollment_payment_term` dan detailnya **tidak** disentuh sama sekali.

## Test plan

- [x] `assets/verify-module.sh` -> `LOLOS: 0 ERROR`
- [x] `assets/validate-unit-test.sh` -> 0 temuan baru (vs-head), 30 temuan warisan tidak terkait perubahan ini
- [x] Skenario YAML: has_scholarship (open/kosong/draft), active_award_id (periode aktif/lewat), amount_scholarship (dua award open dijumlahkan)
- [x] Test Python murni (P1/L-01/L-02) untuk `action_open_scholarship_award` pada kedua model
- [ ] CI GitHub hijau

Closes #7