### PR TITLE
[UPD] ssi_school_scholarship_deduction - wizard penerbitan potongan jatuh tempo

### DIFF
--- a/ssi_school_scholarship_deduction/README.rst
+++ b/ssi_school_scholarship_deduction/README.rst
@@ -23,6 +23,11 @@ Scholarship Deduction
 * `Approve Scholarship Deduction <docs/school_scholarship_deduction/05-approve.html>`_
 * `Cancel Scholarship Deduction <docs/school_scholarship_deduction/10-cancel.html>`_
 
+Scholarship Award
+-----------------------
+
+* `Create Due Deduction - Scholarship Award <docs/school_scholarship_award/07-create-due-deduction.html>`_
+
 
 Installation
 ============

--- a/ssi_school_scholarship_deduction/__manifest__.py
+++ b/ssi_school_scholarship_deduction/__manifest__.py
@@ -26,6 +26,7 @@
         "security/ir_model_access/school_scholarship_deduction.xml",
         "security/ir_model_access/school_scholarship_deduction_line.xml",
         "security/ir_model_access/school_scholarship_deduction_allocation.xml",
+        "security/ir_model_access/create_due_scholarship_deduction.xml",
         "security/ir_rule/school_scholarship_deduction.xml",
         "ir_sequence/school_scholarship_deduction.xml",
         "sequence_template/school_scholarship_deduction.xml",
@@ -33,6 +34,8 @@
         "policy_template/school_scholarship_deduction.xml",
         "menu.xml",
         "views/school_scholarship_deduction.xml",
+        "views/school_scholarship_award.xml",
         "views/assets.xml",
+        "wizards/create_due_scholarship_deduction.xml",
     ],
 }

--- a/ssi_school_scholarship_deduction/docs/school_scholarship_award/07-create-due-deduction.md
+++ b/ssi_school_scholarship_deduction/docs/school_scholarship_award/07-create-due-deduction.md
@@ -1,0 +1,46 @@
+# Create Due Deduction — Scholarship Award
+
+> **Module:** ssi_school_scholarship_deduction\
+> **Extends:** ssi_school_scholarship — model `school_scholarship_award`\
+> **Model:** `school_scholarship_award`\
+> **Menu:** School > Scholarship > Scholarship Awards\
+> **Actor:** user in group `Award User`\
+> **State:** `open` (no state change)\
+> **Requires:** ssi_school_scholarship/school_scholarship_award/05-approve
+
+## Pre-Condition
+
+- **Record:** Status is **On Progress**.
+- **Record:** At least one Schedule line whose own Payment Term is **Invoiced** and
+  whose invoice is **Open**. A line whose Payment Term is not yet invoiced, or already
+  realized, is left untouched.
+- **Config:** An active `policy.template` for this model grants `create_deduction_ok`
+  for state `open` to the actor's group.
+- **Access:** User is in group `Award User`.
+
+## Flow
+
+1. Open the **School > Scholarship > Scholarship Awards** menu.
+2. Either open a single Award's record, or select one or more Award rows directly in the
+   list view.
+3. Click the **Create Due Deduction** button
+   (`action_open_create_due_deduction_wizard`).
+4. In the **Create Due Scholarship Deduction** wizard, the selected Award(s) are
+   pre-filled (not shown on the form).
+5. Fill in the fields:
+   - **Date Start**: Optional. Lower bound (inclusive) on the Schedule line's Date.
+     Leave empty for no lower bound.
+   - **Date End**: Required. Upper bound (inclusive) on the Schedule line's Date.
+6. Click **Create Due Deduction** (`action_create_due_deduction`) in the wizard footer.
+
+## Post-Condition
+
+- One draft `school_scholarship_deduction` document is created per distinct invoice
+  among the due Schedule lines, grouped across every selected Award; an Award with no
+  due Schedule line is skipped without error.
+- Each created document is opened in the Scholarship Deductions list, still in **Draft**
+  status -- it is not confirmed automatically.
+- Every realized Schedule line's own state is left as **Scheduled**; it only becomes
+  **Realized** once its own Deduction document is later opened.
+- If none of the selected Award(s) had a due Schedule line, the wizard raises an error
+  instead of opening an empty list.

--- a/ssi_school_scholarship_deduction/models/__init__.py
+++ b/ssi_school_scholarship_deduction/models/__init__.py
@@ -4,6 +4,7 @@
 
 from . import school_scholarship_award_schedule  # noqa: F401
 from . import school_scholarship_award_funding  # noqa: F401
+from . import school_scholarship_award  # noqa: F401
 from . import school_scholarship_deduction  # noqa: F401
 from . import school_scholarship_deduction_line  # noqa: F401
 from . import school_scholarship_deduction_allocation  # noqa: F401

--- a/ssi_school_scholarship_deduction/models/school_scholarship_award.py
+++ b/ssi_school_scholarship_deduction/models/school_scholarship_award.py
@@ -1,0 +1,263 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import _, models
+from odoo.exceptions import UserError
+
+
+class SchoolScholarshipAward(models.Model):
+    """
+    Extends the scholarship award with the ability to realize its own
+    due Schedule lines into Deduction documents.
+
+    ``_get_due_schedule`` finds the Schedule lines that are safe to
+    realize -- their own Payment Term must already be invoiced, and
+    that invoice must be open, which together make it impossible for
+    a Deduction to be created ahead of its own invoice.
+    ``_create_due_deduction`` then groups those lines by invoice and
+    creates one draft ``school_scholarship_deduction`` per group. Both
+    methods are exercised from the ``create_due_scholarship_deduction``
+    wizard, opened via ``action_open_create_due_deduction_wizard``.
+    """
+
+    _name = "school_scholarship_award"
+    _inherit = "school_scholarship_award"
+
+    def action_open_create_due_deduction_wizard(self):
+        """Open the wizard that realizes due Schedule lines.
+
+        Available both from a single Award's form and from several
+        Awards selected in the Scholarship Awards list view; every
+        selected Award must pass the ``create_deduction_ok`` policy
+        check before the wizard opens.
+
+        :return: an ``ir.actions.act_window`` dict opening
+            ``create_due_scholarship_deduction``, with every selected
+            Award pre-filled in its ``award_ids``
+        """
+        for record in self.sudo():
+            record._check_create_deduction_policy()
+        return self._open_create_due_deduction_wizard()
+
+    def _check_create_deduction_policy(self):
+        """Reject opening the wizard when the policy check fails.
+
+        Mirrors ``_check_generate_schedule_policy`` on this same
+        model: ``create_deduction_ok`` is a ``mixin.policy`` field
+        whose compute only depends on ``policy_template_id``, so it
+        must be busted explicitly in case a stale value was cached
+        before this Award reached Open.
+
+        :raises UserError: when ``create_deduction_ok`` is falsy and
+            the context does not bypass the policy check.
+        """
+        self.ensure_one()
+        if self.env.context.get("bypass_policy_check", False):
+            return True
+        self.invalidate_cache(fnames=["create_deduction_ok"], ids=self.ids)
+        if not self.create_deduction_ok:
+            error_message = """
+Document Type: %s
+Context: Open create due deduction wizard
+Database ID: %s
+Problem: Document is not allowed to create deduction
+Solution: Check create deduction policy prerequisite
+""" % (
+                self._description,
+                self.id,
+            )
+            raise UserError(_(error_message))
+        return True
+
+    def _open_create_due_deduction_wizard(self):
+        """Build the window action opening the due deduction wizard.
+
+        Deliberately operates on the whole ``self`` recordset instead
+        of a single record: the wizard's own ``award_ids`` must be
+        pre-filled with every Award selected in the list view, not
+        just one.
+
+        :return: an ``ir.actions.act_window`` dict targeting ``new``,
+            with every id in this recordset passed through
+            ``active_ids``
+        """
+        waction = self.env.ref(
+            "ssi_school_scholarship_deduction."
+            "create_due_scholarship_deduction_action"
+        ).read()[0]
+        waction.update(
+            {
+                "context": {
+                    "active_model": "school_scholarship_award",
+                    "active_ids": self.ids,
+                },
+            }
+        )
+        return waction
+
+    def _get_due_schedule(self, date_start=False, date_end=False):
+        """Filter this Award's due, invoiced, unrealized Schedule lines.
+
+        A Schedule line is due once its own Payment Term has actually
+        been invoiced (``invoiced``) and that invoice is open
+        (``open``) -- together these two conditions make it
+        impossible for a Deduction to be created ahead of its own
+        invoice. A line already realized never matches (its own
+        ``state`` is no longer ``scheduled``), which is what makes
+        running this twice after the first Deduction opens idempotent.
+
+        :param date_start: earliest Schedule Date to include, or
+            ``False`` for no lower bound
+        :param date_end: latest Schedule Date to include, or
+            ``False`` for no upper bound
+        :return: the ``school_scholarship_award_schedule`` recordset
+            matching every condition above
+        """
+        self.ensure_one()
+        return self.schedule_ids.filtered(
+            lambda schedule: schedule.state == "scheduled"
+            and schedule.payment_term_id.state == "invoiced"
+            and schedule.payment_term_id.customer_invoice_id.state == "open"
+            and (not date_start or schedule.date >= date_start)
+            and (not date_end or schedule.date <= date_end)
+        )
+
+    def _create_due_deduction(self, date_start=False, date_end=False):
+        """Realize this Award's due Schedule lines into Deductions.
+
+        Groups the due Schedule lines returned by
+        ``_get_due_schedule`` by their own linked invoice, then
+        creates one draft ``school_scholarship_deduction`` document
+        per group. Skips silently -- returning an empty recordset --
+        when this Award has no due Schedule line at all, so a mass
+        run from the wizard is never aborted by one uncooperative
+        Award.
+
+        :param date_start: earliest Schedule Date to include, or
+            ``False`` for no lower bound
+        :param date_end: latest Schedule Date to include, or
+            ``False`` for no upper bound
+        :return: the ``school_scholarship_deduction`` recordset
+            created by this call (possibly empty)
+        """
+        self.ensure_one()
+        deductions = self.env["school_scholarship_deduction"]
+        schedules = self._get_due_schedule(date_start, date_end)
+        invoices = schedules.mapped("customer_invoice_id")
+        for invoice in invoices:
+            group = schedules.filtered(
+                lambda schedule, invoice=invoice: schedule.customer_invoice_id
+                == invoice
+            )
+            deductions |= self._create_deduction_for_invoice(invoice, group)
+        return deductions
+
+    def _create_deduction_for_invoice(self, invoice, schedules):
+        """Create one Deduction document realizing one invoice's group.
+
+        The header is created first (with its Lines, one per
+        (Schedule, Funding) pairing), then the single Allocation line
+        is added once the header's own ``amount_total`` has already
+        been computed, so ``amount_allocated`` can be set to it
+        exactly.
+
+        :param invoice: the ``customer_invoice`` every line of
+            ``schedules`` is due against
+        :param schedules: the due ``school_scholarship_award_schedule``
+            recordset to realize, all sharing ``invoice`` as their own
+            Payment Term's invoice
+        :return: the newly created ``school_scholarship_deduction``
+            record
+        """
+        self.ensure_one()
+        deduction = self.env["school_scholarship_deduction"].create(
+            self._prepare_due_deduction_data(invoice, schedules)
+        )
+        deduction.write(
+            {
+                "allocation_ids": [
+                    (
+                        0,
+                        0,
+                        self._prepare_due_deduction_allocation_data(deduction, invoice),
+                    )
+                ],
+            }
+        )
+        return deduction
+
+    def _prepare_due_deduction_data(self, invoice, schedules):
+        """Build the ``school_scholarship_deduction`` header values.
+
+        Extension point: override to carry extra header fields into
+        a newly created document.
+
+        :param invoice: the ``customer_invoice`` this document will
+            eventually be allocated against
+        :param schedules: the ``school_scholarship_award_schedule``
+            recordset this document realizes
+        :return: dict of ``school_scholarship_deduction`` values,
+            including the nested ``line_ids`` commands
+        """
+        self.ensure_one()
+        line_values = []
+        for schedule in schedules:
+            for funding in self.funding_ids:
+                line_values.append(
+                    (
+                        0,
+                        0,
+                        self._prepare_due_deduction_line_data(schedule, funding),
+                    )
+                )
+        return {
+            "award_id": self.id,
+            "journal_id": self.deduction_journal_id.id,
+            "receivable_account_id": invoice.receivable_account_id.id,
+            "line_ids": line_values,
+        }
+
+    def _prepare_due_deduction_line_data(self, schedule, funding):
+        """Build one Deduction Line's values for a (Schedule, Funding) pair.
+
+        Mirrors ``school_scholarship_deduction_line``'s own onchange
+        handlers (``onchange_name``, ``onchange_product_id``,
+        ``onchange_final_account_id``, ``onchange_price_unit``), which
+        never fire on a plain ``create()`` call.
+
+        :param schedule: the due ``school_scholarship_award_schedule``
+            line being realized
+        :param funding: this Award's own
+            ``school_scholarship_award_funding`` line the amount is
+            drawn from
+        :return: dict of ``school_scholarship_deduction_line`` values
+        """
+        self.ensure_one()
+        benefit = schedule.benefit_id
+        return {
+            "schedule_id": schedule.id,
+            "funding_id": funding.id,
+            "name": benefit.name,
+            "product_id": benefit.product_id.id,
+            "final_account_id": benefit.account_id.id,
+            "uom_quantity": 1,
+            "price_unit": schedule.amount_planned * funding.percentage / 100.0,
+        }
+
+    def _prepare_due_deduction_allocation_data(self, deduction, invoice):
+        """Build the single Allocation line's values for one Deduction.
+
+        :param deduction: the just-created ``school_scholarship_deduction``
+            record, its own ``amount_total`` already computed from
+            ``line_ids``
+        :param invoice: the ``customer_invoice`` this Allocation line
+            targets
+        :return: dict of ``school_scholarship_deduction_allocation``
+            values
+        """
+        self.ensure_one()
+        return {
+            "customer_invoice_id": invoice.id,
+            "amount_allocated": deduction.amount_total,
+        }

--- a/ssi_school_scholarship_deduction/security/ir_model_access/create_due_scholarship_deduction.xml
+++ b/ssi_school_scholarship_deduction/security/ir_model_access/create_due_scholarship_deduction.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+<record id="create_due_scholarship_deduction_user_access" model="ir.model.access">
+    <field name="name">create_due_scholarship_deduction - user</field>
+    <field name="model_id" ref="model_create_due_scholarship_deduction" />
+    <field name="group_id" ref="school_scholarship_deduction_user_group" />
+    <field name="perm_read" eval="1" />
+    <field name="perm_create" eval="1" />
+    <field name="perm_write" eval="1" />
+    <field name="perm_unlink" eval="1" />
+</record>
+</odoo>

--- a/ssi_school_scholarship_deduction/static/tests/tours/school_scholarship_award_create_due_deduction_tour.js
+++ b/ssi_school_scholarship_deduction/static/tests/tours/school_scholarship_award_create_due_deduction_tour.js
@@ -1,0 +1,129 @@
+// Copyright 2026 OpenSynergy Indonesia
+// Copyright 2026 PT. Simetri Sinergi Indonesia
+// License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+odoo.define(
+    "ssi_school_scholarship_deduction.school_scholarship_award_create_due_deduction_tour",
+    function (require) {
+        "use strict";
+
+        var tour = require("web_tour.tour");
+
+        // Shared navigation block -- Flow step 1 of
+        // docs/school_scholarship_award/07-create-due-deduction.md:
+        // "Open the School > Scholarship > Scholarship Awards menu."
+        function openScholarshipAwardsList() {
+            return [
+                tour.stepUtils.showAppsMenuItem(),
+                {
+                    content: "Open the School app",
+                    trigger: '.o_app[data-menu-xmlid="ssi_school.menu_school_root"]',
+                },
+                {
+                    content: "Open the Scholarship menu",
+                    trigger:
+                        '.o_menu_sections [data-menu-xmlid="ssi_school_scholarship.menu_school_scholarship"]',
+                },
+                {
+                    content: "Open the Scholarship Awards menu",
+                    trigger:
+                        '.o_menu_sections [data-menu-xmlid="ssi_school_scholarship.school_scholarship_award_menu"]',
+                },
+                {
+                    // Gate: wait for the Scholarship Awards action to
+                    // actually be mounted, not just any list view left
+                    // over from the landing action (patterns.md §A).
+                    content: "Scholarship Awards list is displayed",
+                    trigger:
+                        ".o_control_panel .breadcrumb-item.active:contains(Scholarship Awards)",
+                    extra_trigger: ".o_list_view",
+                    run: function () {
+                        // Assertion only; do not trigger the default click.
+                    },
+                },
+            ];
+        }
+
+        // IK: docs/school_scholarship_award/07-create-due-deduction.md
+        tour.register(
+            "ssi_school_scholarship_deduction_school_scholarship_award_create_due_deduction",
+            {
+                test: true,
+                url: "/web",
+            },
+            [].concat(openScholarshipAwardsList(), [
+                // Flow 2 — Open the record whose due Schedule will be
+                // realized.
+                {
+                    content: "Open the record",
+                    trigger:
+                        ".o_data_row:contains(TOUR-AWARD-CREATEDEDUCTION-001) .o_data_cell:first",
+                },
+                {
+                    content: "Form is open",
+                    trigger: ".o_form_view",
+                    extra_trigger: ".o_form_view.o_form_readonly",
+                    run: function () {
+                        // Assertion only; do not trigger the default click.
+                    },
+                },
+
+                // Flow 3 — Click the Create Due Deduction button.
+                {
+                    content: "Click the Create Due Deduction button",
+                    trigger:
+                        ".o_statusbar_buttons button[name='action_open_create_due_deduction_wizard']",
+                    extra_trigger: ".o_form_view",
+                },
+
+                // ── Flow 4/5 — The wizard opens with the Award already
+                // pre-filled (not shown on the form); fill in Date End.
+                // 14.0 does not prefix in-modal triggers with `.modal`
+                // (odoo-development-ui-test, patterns.md §H note).
+                {
+                    content: "Wizard is open",
+                    trigger: ".o_field_widget[name='date_end']",
+                    run: function () {
+                        // Assertion only; do not trigger the default click.
+                    },
+                },
+                {
+                    content: "Fill in Date End",
+                    trigger: ".o_field_widget[name='date_end'] input",
+                    run: "text 12/31/2026",
+                },
+
+                // Flow 6 — Click Create Due Deduction in the wizard
+                // footer.
+                {
+                    content: "Click Create Due Deduction in the wizard",
+                    trigger: ".modal-footer button[name='action_create_due_deduction']",
+                },
+
+                // ── Post-Condition — the newly created Deduction
+                // document is listed in the Scholarship Deductions
+                // list. Waiting for the Award's own name in the Award
+                // column is the only gate here that is guaranteed
+                // false until the wizard's own RPC actually finishes
+                // (patterns.md §P): no such row exists before this
+                // wizard is run.
+                {
+                    content: "Scholarship Deductions list is displayed",
+                    trigger:
+                        ".o_control_panel .breadcrumb-item.active:contains(Scholarship Deductions)",
+                    extra_trigger: ".o_list_view",
+                    run: function () {
+                        // Assertion only; do not trigger the default click.
+                    },
+                },
+                {
+                    content: "A Deduction for the Award appears in Draft",
+                    trigger: ".o_data_row:contains(TOUR-AWARD-CREATEDEDUCTION-001)",
+                    run: function () {
+                        // Assertion only; do not trigger the default click.
+                    },
+                },
+            ])
+        );
+    }
+);

--- a/ssi_school_scholarship_deduction/tests/__init__.py
+++ b/ssi_school_scholarship_deduction/tests/__init__.py
@@ -4,3 +4,5 @@
 
 from . import test_school_scholarship_deduction  # noqa: F401
 from . import test_ui_school_scholarship_deduction  # noqa: F401
+from . import test_school_scholarship_award_create_due_deduction  # noqa: F401
+from . import test_ui_school_scholarship_award_create_due_deduction  # noqa: F401

--- a/ssi_school_scholarship_deduction/tests/test_data_school_scholarship_award_create_due_deduction.yaml
+++ b/ssi_school_scholarship_deduction/tests/test_data_school_scholarship_award_create_due_deduction.yaml
@@ -1,0 +1,1045 @@
+options:
+  auto_refresh: true
+scenarios:
+  - name: "Award Create Due Deduction - Group By Invoice, Skip Not-Yet-Due, Idempotent"
+    steps:
+      # ── Shared fixture chain (prefix CDD) ────────────────────────
+      - step: "Create the grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "cdd_grade_type"
+        values:
+          name: "CDD Grade Type"
+          code: "CDDGT"
+
+      - step: "Create the school"
+        action: "create"
+        model: "school"
+        save_as: "cdd_school"
+        values:
+          name: "CDD School"
+          code: "CDDSC"
+          grade_type_id: "REC: cdd_grade_type.id"
+
+      - step: "Create the academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "cdd_academic_year"
+        values:
+          name: "CDD Academic Year"
+          code: "CDDAY"
+          date_start: 2026-07-01
+          date_end: 2027-06-30
+
+      - step: "Create the academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "cdd_academic_term"
+        values:
+          name: "CDD Term"
+          code: "CDDTM"
+          date_start: 2026-07-01
+          date_end: 2026-12-31
+          year_id: "REC: cdd_academic_year.id"
+
+      - step: "Create the grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "cdd_grade"
+        values:
+          name: "CDD Grade"
+          code: "CDDGR"
+          type_id: "REC: cdd_grade_type.id"
+
+      - step: "Create the grade class"
+        action: "create"
+        model: "school_grade_class"
+        save_as: "cdd_grade_class"
+        values:
+          name: "CDD Class"
+          code: "CDDCL"
+          school_id: "REC: cdd_school.id"
+          grade_id: "REC: cdd_grade.id"
+
+      - step: "Create the student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "cdd_contact"
+        values:
+          name: "CDD Contact"
+
+      - step: "Create the student"
+        action: "create"
+        model: "school_student"
+        save_as: "cdd_student"
+        values:
+          name: "CDD Student"
+          code: "CDDST"
+          contact_id: "REC: cdd_contact.id"
+          school_id: "REC: cdd_school.id"
+
+      - step: "Create the enrollment"
+        action: "create"
+        model: "school_enrollment"
+        save_as: "cdd_enrollment"
+        values:
+          academic_year_id: "REC: cdd_academic_year.id"
+          academic_term_id: "REC: cdd_academic_term.id"
+          school_id: "REC: cdd_school.id"
+          grade_id: "REC: cdd_grade.id"
+          grade_class_id: "REC: cdd_grade_class.id"
+          student_id: "REC: cdd_student.id"
+
+      # Confirm/Approve so school_enrollment_payment_term._compute_state
+      # can ever read "invoiced" -- it only does so once its own
+      # enrollment_id.state is "open" or "done".
+      - step: "Confirm the enrollment as admin"
+        action: "call"
+        target: "cdd_enrollment"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+
+      - step: "Approve the enrollment as admin (opens it)"
+        action: "call"
+        target: "cdd_enrollment"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+      - step: "Get the account.account.type Income reference"
+        action: "ref"
+        xml_id: "account.data_account_type_revenue"
+        save_as: "account_type_income"
+
+      - step: "Get the account.account.type Receivable reference"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "account_type_receivable"
+
+      - step: "Create the receivable account shared by invoices and deductions"
+        action: "create"
+        model: "account.account"
+        save_as: "cdd_receivable_account"
+        values:
+          name: "CDD Receivable Account"
+          code: "CDDRA"
+          user_type_id: "REC: account_type_receivable.id"
+          reconcile: true
+
+      - step: "Create the discount account the deduction lines post to"
+        action: "create"
+        model: "account.account"
+        save_as: "cdd_discount_account"
+        values:
+          name: "CDD Discount Account"
+          code: "CDDDA"
+          user_type_id: "REC: account_type_income.id"
+          reconcile: false
+
+      - step: "Create the income account the invoice lines post to"
+        action: "create"
+        model: "account.account"
+        save_as: "cdd_income_account"
+        values:
+          name: "CDD Income Account"
+          code: "CDDIA"
+          user_type_id: "REC: account_type_income.id"
+          reconcile: false
+
+      - step: "Create the sale journal"
+        action: "create"
+        model: "account.journal"
+        save_as: "cdd_journal"
+        values:
+          name: "CDD Journal"
+          code: "JCDD"
+          type: "sale"
+
+      - step: "Create the customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "cdd_invoice_type"
+        values:
+          name: "CDD Invoice Type"
+          code: "/"
+          journal_id: "REC: cdd_journal.id"
+          receivable_account_id: "REC: cdd_receivable_account.id"
+
+      - step: "Create the analytic account for funding source A"
+        action: "create"
+        model: "account.analytic.account"
+        save_as: "cdd_analytic_a"
+        values:
+          name: "CDD Analytic A"
+
+      - step: "Create the analytic account for funding source B"
+        action: "create"
+        model: "account.analytic.account"
+        save_as: "cdd_analytic_b"
+        values:
+          name: "CDD Analytic B"
+
+      - step: "Create funding source A"
+        action: "create"
+        model: "school_scholarship_funding_source"
+        save_as: "cdd_funding_source_a"
+        values:
+          name: "CDD Funding Source A"
+          code: "CDDFA"
+          analytic_account_id: "REC: cdd_analytic_a.id"
+
+      - step: "Create funding source B"
+        action: "create"
+        model: "school_scholarship_funding_source"
+        save_as: "cdd_funding_source_b"
+        values:
+          name: "CDD Funding Source B"
+          code: "CDDFB"
+          analytic_account_id: "REC: cdd_analytic_b.id"
+
+      - step: "Create the product covered by the benefit lines"
+        action: "create"
+        model: "product.product"
+        save_as: "cdd_product"
+        values:
+          name: "CDD Product"
+          type: "service"
+
+      - step: "Create the scholarship type"
+        action: "create"
+        model: "school_scholarship_type"
+        save_as: "cdd_type"
+        values:
+          name: "CDD Type"
+          code: "CDDTY"
+          deduction_journal_id: "REC: cdd_journal.id"
+          discount_account_id: "REC: cdd_discount_account.id"
+
+      - step: "Create the scholarship program (Fee Reduction, 40%)"
+        action: "create"
+        model: "school_scholarship_program"
+        save_as: "cdd_program"
+        values:
+          name: "CDD Program"
+          code: "CDDPRG"
+          type_id: "REC: cdd_type.id"
+          school_id: "REC: cdd_school.id"
+          academic_year_id: "REC: cdd_academic_year.id"
+          funding_source_ids:
+            [[6, 0, ["REC: cdd_funding_source_a.id", "REC: cdd_funding_source_b.id"]]]
+          deduction_journal_id: "REC: cdd_journal.id"
+          discount_account_id: "REC: cdd_discount_account.id"
+          scope_ids:
+            - - 0
+              - 0
+              - scope_basis: "product"
+                product_id: "REC: cdd_product.id"
+                benefit_type: "fee_reduction"
+                computation: "percentage"
+                percentage: 40.0
+
+      # ══════════════════════════════════════════════════════════════
+      # Sub-case A -- two of three Schedule lines are due (their own
+      # Payment Term already invoiced and open); the third's Payment
+      # Term is still uninvoiced and is left untouched. The Award is
+      # funded by two sources, so each resulting Deduction gets two
+      # Lines.
+      # ══════════════════════════════════════════════════════════════
+      - step: "A: create Payment Term 1 (will be invoiced and opened)"
+        action: "create"
+        model: "school_enrollment_payment_term"
+        save_as: "cdd_a_term1"
+        values:
+          enrollment_id: "REC: cdd_enrollment.id"
+          name: "CDD A Term 1"
+          date_invoice: 2026-08-01
+          detail_ids:
+            - - 0
+              - 0
+              - product_id: "REC: cdd_product.id"
+                name: "CDD A Term 1 Fee"
+                account_id: "REC: cdd_income_account.id"
+                uom_quantity: 1.0
+                uom_id: "REF: uom.product_uom_unit"
+                price_unit: 1000000.0
+
+      - step: "A: create Payment Term 2 (will be invoiced and opened)"
+        action: "create"
+        model: "school_enrollment_payment_term"
+        save_as: "cdd_a_term2"
+        values:
+          enrollment_id: "REC: cdd_enrollment.id"
+          name: "CDD A Term 2"
+          date_invoice: 2026-09-01
+          detail_ids:
+            - - 0
+              - 0
+              - product_id: "REC: cdd_product.id"
+                name: "CDD A Term 2 Fee"
+                account_id: "REC: cdd_income_account.id"
+                uom_quantity: 1.0
+                uom_id: "REF: uom.product_uom_unit"
+                price_unit: 1000000.0
+
+      - step: "A: create Payment Term 3 (left uninvoiced)"
+        action: "create"
+        model: "school_enrollment_payment_term"
+        save_as: "cdd_a_term3"
+        values:
+          enrollment_id: "REC: cdd_enrollment.id"
+          name: "CDD A Term 3"
+          date_invoice: 2026-10-01
+          detail_ids:
+            - - 0
+              - 0
+              - product_id: "REC: cdd_product.id"
+                name: "CDD A Term 3 Fee"
+                account_id: "REC: cdd_income_account.id"
+                uom_quantity: 1.0
+                uom_id: "REF: uom.product_uom_unit"
+                price_unit: 1000000.0
+
+      - step: "A: create the invoice for Term 1"
+        action: "create"
+        model: "customer_invoice"
+        save_as: "cdd_a_invoice1"
+        values:
+          name: "CDD-A-INV-001"
+          type_id: "REC: cdd_invoice_type.id"
+          partner_id: "REC: cdd_contact.id"
+          date: 2026-08-01
+          date_due: 2026-08-15
+          currency_id: "REC: company.currency_id.id"
+          journal_id: "REC: cdd_journal.id"
+          receivable_account_id: "REC: cdd_receivable_account.id"
+          user_id: "REF: base.user_admin"
+
+      - step: "A: confirm the Term 1 invoice"
+        action: "call"
+        target: "cdd_a_invoice1"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+        refresh: true
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
+
+      - step: "A: approve the Term 1 invoice (opens it)"
+        action: "call"
+        target: "cdd_a_invoice1"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        refresh: true
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+      - step: "A: link the invoice to Term 1"
+        action: "write"
+        target: "cdd_a_term1"
+        values:
+          customer_invoice_id: "REC: cdd_a_invoice1.id"
+
+      - step: "A: create the invoice for Term 2"
+        action: "create"
+        model: "customer_invoice"
+        save_as: "cdd_a_invoice2"
+        values:
+          name: "CDD-A-INV-002"
+          type_id: "REC: cdd_invoice_type.id"
+          partner_id: "REC: cdd_contact.id"
+          date: 2026-09-01
+          date_due: 2026-09-15
+          currency_id: "REC: company.currency_id.id"
+          journal_id: "REC: cdd_journal.id"
+          receivable_account_id: "REC: cdd_receivable_account.id"
+          user_id: "REF: base.user_admin"
+
+      - step: "A: confirm the Term 2 invoice"
+        action: "call"
+        target: "cdd_a_invoice2"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+        refresh: true
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
+
+      - step: "A: approve the Term 2 invoice (opens it)"
+        action: "call"
+        target: "cdd_a_invoice2"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        refresh: true
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+      - step: "A: link the invoice to Term 2"
+        action: "write"
+        target: "cdd_a_term2"
+        values:
+          customer_invoice_id: "REC: cdd_a_invoice2.id"
+
+      - step: "A: assert Term 1 and 2 are invoiced, Term 3 is not"
+        action: "assert"
+        target: "cdd_a_term1"
+        asserts:
+          state:
+            type: "value"
+            expected: "invoiced"
+
+      - step: "A: assert Term 2 is invoiced"
+        action: "assert"
+        target: "cdd_a_term2"
+        asserts:
+          state:
+            type: "value"
+            expected: "invoiced"
+
+      - step: "A: assert Term 3 is still uninvoiced"
+        action: "assert"
+        target: "cdd_a_term3"
+        asserts:
+          state:
+            type: "value"
+            expected: "uninvoiced"
+
+      - step: "A: create the award, funded by two sources (60/40)"
+        action: "create"
+        model: "school_scholarship_award"
+        save_as: "cdd_a_award"
+        values:
+          name: "CDD-A-AWARD-001"
+          program_id: "REC: cdd_program.id"
+          student_id: "REC: cdd_student.id"
+          enrollment_id: "REC: cdd_enrollment.id"
+          date_start: 2026-07-01
+          date_end: 2026-12-31
+          discount_account_id: "REC: cdd_discount_account.id"
+          deduction_journal_id: "REC: cdd_journal.id"
+          user_id: "REF: base.user_admin"
+          benefit_ids:
+            - - 0
+              - 0
+              - name: "CDD A Benefit"
+                product_id: "REC: cdd_product.id"
+                percentage: 40.0
+          funding_ids:
+            - - 0
+              - 0
+              - funding_source_id: "REC: cdd_funding_source_a.id"
+                percentage: 60.0
+            - - 0
+              - 0
+              - funding_source_id: "REC: cdd_funding_source_b.id"
+                percentage: 40.0
+
+      - step: "A: find the award's Benefit line"
+        action: "search"
+        model: "school_scholarship_award_benefit"
+        domain: [["award_id", "=", "REC: cdd_a_award.id"]]
+        limit: 1
+        save_as: "cdd_a_benefit"
+
+      - step: "A: create the Schedule line for Term 1 (due)"
+        action: "create"
+        model: "school_scholarship_award_schedule"
+        save_as: "cdd_a_schedule1"
+        values:
+          benefit_id: "REC: cdd_a_benefit.id"
+          payment_term_id: "REC: cdd_a_term1.id"
+          date: "REC: cdd_a_term1.date_invoice"
+          state: "scheduled"
+
+      - step: "A: create the Schedule line for Term 2 (due)"
+        action: "create"
+        model: "school_scholarship_award_schedule"
+        save_as: "cdd_a_schedule2"
+        values:
+          benefit_id: "REC: cdd_a_benefit.id"
+          payment_term_id: "REC: cdd_a_term2.id"
+          date: "REC: cdd_a_term2.date_invoice"
+          state: "scheduled"
+
+      - step: "A: create the Schedule line for Term 3 (not due)"
+        action: "create"
+        model: "school_scholarship_award_schedule"
+        save_as: "cdd_a_schedule3"
+        values:
+          benefit_id: "REC: cdd_a_benefit.id"
+          payment_term_id: "REC: cdd_a_term3.id"
+          date: "REC: cdd_a_term3.date_invoice"
+          state: "scheduled"
+
+      - step: "A: assert Schedule 1's Amount Planned is 40% of the base"
+        action: "assert"
+        target: "cdd_a_schedule1"
+        asserts:
+          amount_planned:
+            type: "value"
+            expected: 400000.0
+
+      - step: "A: run _create_due_deduction on the award (no date range)"
+        action: "call"
+        target: "cdd_a_award"
+        method: "_create_due_deduction"
+
+      - step: "A: assert exactly two Deductions were created"
+        action: "search"
+        model: "school_scholarship_deduction"
+        domain: [["award_id", "=", "REC: cdd_a_award.id"]]
+        save_as: "cdd_a_deductions"
+        expect_count: 2
+
+      - step: "A: find the Deduction allocated to invoice 1"
+        action: "search"
+        model: "school_scholarship_deduction"
+        domain:
+          [
+            ["award_id", "=", "REC: cdd_a_award.id"],
+            ["allocation_ids.customer_invoice_id", "=", "REC: cdd_a_invoice1.id"],
+          ]
+        limit: 1
+        save_as: "cdd_a_deduction1"
+
+      - step: "A: assert the Deduction for invoice 1 is Draft with two Lines"
+        action: "assert"
+        target: "cdd_a_deduction1"
+        asserts:
+          state:
+            type: "value"
+            expected: "draft"
+          amount_total:
+            type: "value"
+            expected: 400000.0
+          amount_allocated:
+            type: "value"
+            expected: 400000.0
+          amount_unallocated:
+            type: "value"
+            expected: 0.0
+          receivable_account_id:
+            type: "m2o"
+            expected: "REC: cdd_receivable_account"
+          line_ids:
+            type: "o2m"
+            check: "count"
+            expected_count: 2
+          allocation_ids:
+            type: "o2m"
+            check: "count"
+            expected_count: 1
+
+      - step: "A: assert Schedule 1/2 are still Scheduled (not yet realized)"
+        action: "assert"
+        target: "cdd_a_schedule1"
+        asserts:
+          state:
+            type: "value"
+            expected: "scheduled"
+
+      - step: "A: assert Schedule 2 is still Scheduled"
+        action: "assert"
+        target: "cdd_a_schedule2"
+        asserts:
+          state:
+            type: "value"
+            expected: "scheduled"
+
+      - step: "A: assert Schedule 3 (not due) was never touched"
+        action: "assert"
+        target: "cdd_a_schedule3"
+        asserts:
+          state:
+            type: "value"
+            expected: "scheduled"
+
+      # ══════════════════════════════════════════════════════════════
+      # Sub-case B -- idempotent: once the Deduction actually opens
+      # (realizing its own Schedule line), running
+      # _create_due_deduction a second time creates nothing new.
+      # ══════════════════════════════════════════════════════════════
+      - step: "B: create the Payment Term"
+        action: "create"
+        model: "school_enrollment_payment_term"
+        save_as: "cdd_b_term"
+        values:
+          enrollment_id: "REC: cdd_enrollment.id"
+          name: "CDD B Term"
+          date_invoice: 2026-08-01
+          detail_ids:
+            - - 0
+              - 0
+              - product_id: "REC: cdd_product.id"
+                name: "CDD B Term Fee"
+                account_id: "REC: cdd_income_account.id"
+                uom_quantity: 1.0
+                uom_id: "REF: uom.product_uom_unit"
+                price_unit: 1000000.0
+
+      - step: "B: create and open the invoice"
+        action: "create"
+        model: "customer_invoice"
+        save_as: "cdd_b_invoice"
+        values:
+          name: "CDD-B-INV-001"
+          type_id: "REC: cdd_invoice_type.id"
+          partner_id: "REC: cdd_contact.id"
+          date: 2026-08-01
+          date_due: 2026-08-15
+          currency_id: "REC: company.currency_id.id"
+          journal_id: "REC: cdd_journal.id"
+          receivable_account_id: "REC: cdd_receivable_account.id"
+          user_id: "REF: base.user_admin"
+
+      - step: "B: confirm the invoice"
+        action: "call"
+        target: "cdd_b_invoice"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+        refresh: true
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
+
+      - step: "B: approve the invoice (opens it)"
+        action: "call"
+        target: "cdd_b_invoice"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        refresh: true
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+      - step: "B: link the invoice to the term"
+        action: "write"
+        target: "cdd_b_term"
+        values:
+          customer_invoice_id: "REC: cdd_b_invoice.id"
+
+      - step: "B: create the award (single funding source, 100%)"
+        action: "create"
+        model: "school_scholarship_award"
+        save_as: "cdd_b_award"
+        values:
+          name: "CDD-B-AWARD-001"
+          program_id: "REC: cdd_program.id"
+          student_id: "REC: cdd_student.id"
+          enrollment_id: "REC: cdd_enrollment.id"
+          date_start: 2026-07-01
+          date_end: 2026-12-31
+          discount_account_id: "REC: cdd_discount_account.id"
+          deduction_journal_id: "REC: cdd_journal.id"
+          user_id: "REF: base.user_admin"
+          benefit_ids:
+            - - 0
+              - 0
+              - name: "CDD B Benefit"
+                product_id: "REC: cdd_product.id"
+                percentage: 100.0
+          funding_ids:
+            - - 0
+              - 0
+              - funding_source_id: "REC: cdd_funding_source_a.id"
+                percentage: 100.0
+
+      - step: "B: find the award's Benefit line"
+        action: "search"
+        model: "school_scholarship_award_benefit"
+        domain: [["award_id", "=", "REC: cdd_b_award.id"]]
+        limit: 1
+        save_as: "cdd_b_benefit"
+
+      - step: "B: create the due Schedule line"
+        action: "create"
+        model: "school_scholarship_award_schedule"
+        save_as: "cdd_b_schedule"
+        values:
+          benefit_id: "REC: cdd_b_benefit.id"
+          payment_term_id: "REC: cdd_b_term.id"
+          date: "REC: cdd_b_term.date_invoice"
+          state: "scheduled"
+
+      - step: "B: run _create_due_deduction on the award (first time)"
+        action: "call"
+        target: "cdd_b_award"
+        method: "_create_due_deduction"
+
+      - step: "B: assert exactly one Deduction was created"
+        action: "search"
+        model: "school_scholarship_deduction"
+        domain: [["award_id", "=", "REC: cdd_b_award.id"]]
+        save_as: "cdd_b_deduction"
+        limit: 1
+        expect_count: 1
+
+      - step: "B: confirm the Deduction"
+        action: "call"
+        target: "cdd_b_deduction"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
+
+      - step: "B: approve the Deduction, opening it and realizing the Schedule"
+        action: "call"
+        target: "cdd_b_deduction"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+      - step: "B: assert the Schedule line is now Realized"
+        action: "assert"
+        target: "cdd_b_schedule"
+        asserts:
+          state:
+            type: "value"
+            expected: "realized"
+
+      - step: "B: run _create_due_deduction again (second time)"
+        action: "call"
+        target: "cdd_b_award"
+        method: "_create_due_deduction"
+
+      - step: "B: assert no new Deduction was created"
+        action: "search"
+        model: "school_scholarship_deduction"
+        domain: [["award_id", "=", "REC: cdd_b_award.id"]]
+        save_as: "cdd_b_deductions_after"
+        expect_count: 1
+
+      # ══════════════════════════════════════════════════════════════
+      # Sub-case C -- the wizard, run against two different Awards at
+      # once, produces two separate Deductions, each with its own
+      # award_id.
+      # ══════════════════════════════════════════════════════════════
+      - step: "C: create the Payment Term for Award 1"
+        action: "create"
+        model: "school_enrollment_payment_term"
+        save_as: "cdd_c_term1"
+        values:
+          enrollment_id: "REC: cdd_enrollment.id"
+          name: "CDD C Term 1"
+          date_invoice: 2026-08-01
+          detail_ids:
+            - - 0
+              - 0
+              - product_id: "REC: cdd_product.id"
+                name: "CDD C Term 1 Fee"
+                account_id: "REC: cdd_income_account.id"
+                uom_quantity: 1.0
+                uom_id: "REF: uom.product_uom_unit"
+                price_unit: 1000000.0
+
+      - step: "C: create and open the invoice for Term 1"
+        action: "create"
+        model: "customer_invoice"
+        save_as: "cdd_c_invoice1"
+        values:
+          name: "CDD-C-INV-001"
+          type_id: "REC: cdd_invoice_type.id"
+          partner_id: "REC: cdd_contact.id"
+          date: 2026-08-01
+          date_due: 2026-08-15
+          currency_id: "REC: company.currency_id.id"
+          journal_id: "REC: cdd_journal.id"
+          receivable_account_id: "REC: cdd_receivable_account.id"
+          user_id: "REF: base.user_admin"
+
+      - step: "C: confirm the Term 1 invoice"
+        action: "call"
+        target: "cdd_c_invoice1"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+        refresh: true
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
+
+      - step: "C: approve the Term 1 invoice"
+        action: "call"
+        target: "cdd_c_invoice1"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        refresh: true
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+      - step: "C: link the invoice to Term 1"
+        action: "write"
+        target: "cdd_c_term1"
+        values:
+          customer_invoice_id: "REC: cdd_c_invoice1.id"
+
+      - step: "C: create the Payment Term for Award 2"
+        action: "create"
+        model: "school_enrollment_payment_term"
+        save_as: "cdd_c_term2"
+        values:
+          enrollment_id: "REC: cdd_enrollment.id"
+          name: "CDD C Term 2"
+          date_invoice: 2026-09-01
+          detail_ids:
+            - - 0
+              - 0
+              - product_id: "REC: cdd_product.id"
+                name: "CDD C Term 2 Fee"
+                account_id: "REC: cdd_income_account.id"
+                uom_quantity: 1.0
+                uom_id: "REF: uom.product_uom_unit"
+                price_unit: 1000000.0
+
+      - step: "C: create and open the invoice for Term 2"
+        action: "create"
+        model: "customer_invoice"
+        save_as: "cdd_c_invoice2"
+        values:
+          name: "CDD-C-INV-002"
+          type_id: "REC: cdd_invoice_type.id"
+          partner_id: "REC: cdd_contact.id"
+          date: 2026-09-01
+          date_due: 2026-09-15
+          currency_id: "REC: company.currency_id.id"
+          journal_id: "REC: cdd_journal.id"
+          receivable_account_id: "REC: cdd_receivable_account.id"
+          user_id: "REF: base.user_admin"
+
+      - step: "C: confirm the Term 2 invoice"
+        action: "call"
+        target: "cdd_c_invoice2"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+        refresh: true
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
+
+      - step: "C: approve the Term 2 invoice"
+        action: "call"
+        target: "cdd_c_invoice2"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        refresh: true
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+      - step: "C: link the invoice to Term 2"
+        action: "write"
+        target: "cdd_c_term2"
+        values:
+          customer_invoice_id: "REC: cdd_c_invoice2.id"
+
+      - step: "C: create Award 1"
+        action: "create"
+        model: "school_scholarship_award"
+        save_as: "cdd_c_award1"
+        values:
+          name: "CDD-C-AWARD-001"
+          program_id: "REC: cdd_program.id"
+          student_id: "REC: cdd_student.id"
+          enrollment_id: "REC: cdd_enrollment.id"
+          date_start: 2026-07-01
+          date_end: 2026-12-31
+          discount_account_id: "REC: cdd_discount_account.id"
+          deduction_journal_id: "REC: cdd_journal.id"
+          user_id: "REF: base.user_admin"
+          benefit_ids:
+            - - 0
+              - 0
+              - name: "CDD C Benefit 1"
+                product_id: "REC: cdd_product.id"
+                percentage: 100.0
+          funding_ids:
+            - - 0
+              - 0
+              - funding_source_id: "REC: cdd_funding_source_a.id"
+                percentage: 100.0
+
+      - step: "C: create Award 2"
+        action: "create"
+        model: "school_scholarship_award"
+        save_as: "cdd_c_award2"
+        values:
+          name: "CDD-C-AWARD-002"
+          program_id: "REC: cdd_program.id"
+          student_id: "REC: cdd_student.id"
+          enrollment_id: "REC: cdd_enrollment.id"
+          date_start: 2026-07-01
+          date_end: 2026-12-31
+          discount_account_id: "REC: cdd_discount_account.id"
+          deduction_journal_id: "REC: cdd_journal.id"
+          user_id: "REF: base.user_admin"
+          benefit_ids:
+            - - 0
+              - 0
+              - name: "CDD C Benefit 2"
+                product_id: "REC: cdd_product.id"
+                percentage: 100.0
+          funding_ids:
+            - - 0
+              - 0
+              - funding_source_id: "REC: cdd_funding_source_a.id"
+                percentage: 100.0
+
+      - step: "C: find Award 1's Benefit line"
+        action: "search"
+        model: "school_scholarship_award_benefit"
+        domain: [["award_id", "=", "REC: cdd_c_award1.id"]]
+        limit: 1
+        save_as: "cdd_c_benefit1"
+
+      - step: "C: find Award 2's Benefit line"
+        action: "search"
+        model: "school_scholarship_award_benefit"
+        domain: [["award_id", "=", "REC: cdd_c_award2.id"]]
+        limit: 1
+        save_as: "cdd_c_benefit2"
+
+      - step: "C: create the Schedule line for Award 1"
+        action: "create"
+        model: "school_scholarship_award_schedule"
+        save_as: "cdd_c_schedule1"
+        values:
+          benefit_id: "REC: cdd_c_benefit1.id"
+          payment_term_id: "REC: cdd_c_term1.id"
+          date: "REC: cdd_c_term1.date_invoice"
+          state: "scheduled"
+
+      - step: "C: create the Schedule line for Award 2"
+        action: "create"
+        model: "school_scholarship_award_schedule"
+        save_as: "cdd_c_schedule2"
+        values:
+          benefit_id: "REC: cdd_c_benefit2.id"
+          payment_term_id: "REC: cdd_c_term2.id"
+          date: "REC: cdd_c_term2.date_invoice"
+          state: "scheduled"
+
+      - step: "C: create the wizard with both Awards selected"
+        action: "create"
+        model: "create_due_scholarship_deduction"
+        save_as: "cdd_c_wizard"
+        values:
+          award_ids: [[6, 0, ["REC: cdd_c_award1.id", "REC: cdd_c_award2.id"]]]
+          date_end: 2026-12-31
+
+      - step: "C: run the wizard"
+        action: "call"
+        target: "cdd_c_wizard"
+        method: "action_create_due_deduction"
+
+      - step: "C: assert Award 1 got exactly one Deduction"
+        action: "search"
+        model: "school_scholarship_deduction"
+        domain: [["award_id", "=", "REC: cdd_c_award1.id"]]
+        save_as: "cdd_c_deductions1"
+        expect_count: 1
+
+      - step: "C: assert Award 2 got exactly one Deduction"
+        action: "search"
+        model: "school_scholarship_deduction"
+        domain: [["award_id", "=", "REC: cdd_c_award2.id"]]
+        save_as: "cdd_c_deductions2"
+        expect_count: 1
+
+      # ══════════════════════════════════════════════════════════════
+      # Sub-case D -- negative: the wizard raises when none of the
+      # selected Award(s) has a due Schedule line at all.
+      # ══════════════════════════════════════════════════════════════
+      - step: "D: create the Payment Term (left uninvoiced)"
+        action: "create"
+        model: "school_enrollment_payment_term"
+        save_as: "cdd_d_term"
+        values:
+          enrollment_id: "REC: cdd_enrollment.id"
+          name: "CDD D Term"
+          date_invoice: 2026-08-01
+          detail_ids:
+            - - 0
+              - 0
+              - product_id: "REC: cdd_product.id"
+                name: "CDD D Term Fee"
+                account_id: "REC: cdd_income_account.id"
+                uom_quantity: 1.0
+                uom_id: "REF: uom.product_uom_unit"
+                price_unit: 1000000.0
+
+      - step: "D: create the award"
+        action: "create"
+        model: "school_scholarship_award"
+        save_as: "cdd_d_award"
+        values:
+          name: "CDD-D-AWARD-001"
+          program_id: "REC: cdd_program.id"
+          student_id: "REC: cdd_student.id"
+          enrollment_id: "REC: cdd_enrollment.id"
+          date_start: 2026-07-01
+          date_end: 2026-12-31
+          discount_account_id: "REC: cdd_discount_account.id"
+          deduction_journal_id: "REC: cdd_journal.id"
+          user_id: "REF: base.user_admin"
+          benefit_ids:
+            - - 0
+              - 0
+              - name: "CDD D Benefit"
+                product_id: "REC: cdd_product.id"
+                percentage: 100.0
+          funding_ids:
+            - - 0
+              - 0
+              - funding_source_id: "REC: cdd_funding_source_a.id"
+                percentage: 100.0
+
+      - step: "D: find the award's Benefit line"
+        action: "search"
+        model: "school_scholarship_award_benefit"
+        domain: [["award_id", "=", "REC: cdd_d_award.id"]]
+        limit: 1
+        save_as: "cdd_d_benefit"
+
+      - step: "D: create the (not due) Schedule line"
+        action: "create"
+        model: "school_scholarship_award_schedule"
+        save_as: "cdd_d_schedule"
+        values:
+          benefit_id: "REC: cdd_d_benefit.id"
+          payment_term_id: "REC: cdd_d_term.id"
+          date: "REC: cdd_d_term.date_invoice"
+          state: "scheduled"
+
+      - step: "D: create the wizard"
+        action: "create"
+        model: "create_due_scholarship_deduction"
+        save_as: "cdd_d_wizard"
+        values:
+          award_ids: [[6, 0, ["REC: cdd_d_award.id"]]]
+          date_end: 2026-12-31
+
+      - step: "D: run the wizard, expecting a UserError"
+        action: "call"
+        target: "cdd_d_wizard"
+        method: "action_create_due_deduction"
+        expect_error:
+          type: "UserError"

--- a/ssi_school_scholarship_deduction/tests/test_data_school_scholarship_award_create_due_deduction.yaml
+++ b/ssi_school_scholarship_deduction/tests/test_data_school_scholarship_award_create_due_deduction.yaml
@@ -1107,3 +1107,27 @@ scenarios:
         method: "action_create_due_deduction"
         expect_error:
           type: "UserError"
+
+      # ══════════════════════════════════════════════════════════════
+      # Sub-case E -- negative: opening the wizard on a Draft Award
+      # (never confirmed) is rejected by the create_deduction_ok
+      # policy, which only grants it in state Open.
+      # ══════════════════════════════════════════════════════════════
+      - step: "E: create a Draft award (never confirmed)"
+        action: "create"
+        model: "school_scholarship_award"
+        save_as: "cdd_e_award"
+        values:
+          name: "CDD-E-AWARD-001"
+          program_id: "REC: cdd_program.id"
+          student_id: "REC: cdd_student.id"
+          enrollment_id: "REC: cdd_enrollment.id"
+          date_start: 2026-07-01
+          date_end: 2026-12-31
+
+      - step: "E: opening the wizard on a Draft award is rejected"
+        action: "call"
+        target: "cdd_e_award"
+        method: "action_open_create_due_deduction_wizard"
+        expect_error:
+          type: "UserError"

--- a/ssi_school_scholarship_deduction/tests/test_data_school_scholarship_award_create_due_deduction.yaml
+++ b/ssi_school_scholarship_deduction/tests/test_data_school_scholarship_award_create_due_deduction.yaml
@@ -326,6 +326,17 @@ scenarios:
           receivable_account_id: "REC: cdd_receivable_account.id"
           user_id: "REF: base.user_admin"
 
+      - step: "Add a Line to CDD A Invoice 1 (needed to stop at Open, not Done)"
+        action: "create"
+        model: "customer_invoice.line"
+        save_as: "cdd_a_invoice1_line"
+        values:
+          customer_invoice_id: "REC: cdd_a_invoice1.id"
+          name: "CDD A Invoice 1 Line"
+          account_id: "REC: cdd_income_account.id"
+          uom_quantity: 1.0
+          price_unit: 1000000.0
+
       - step: "A: confirm the Term 1 invoice"
         action: "call"
         target: "cdd_a_invoice1"
@@ -368,6 +379,17 @@ scenarios:
           journal_id: "REC: cdd_journal.id"
           receivable_account_id: "REC: cdd_receivable_account.id"
           user_id: "REF: base.user_admin"
+
+      - step: "Add a Line to CDD A Invoice 2 (needed to stop at Open, not Done)"
+        action: "create"
+        model: "customer_invoice.line"
+        save_as: "cdd_a_invoice2_line"
+        values:
+          customer_invoice_id: "REC: cdd_a_invoice2.id"
+          name: "CDD A Invoice 2 Line"
+          account_id: "REC: cdd_income_account.id"
+          uom_quantity: 1.0
+          price_unit: 1000000.0
 
       - step: "A: confirm the Term 2 invoice"
         action: "call"
@@ -609,6 +631,17 @@ scenarios:
           receivable_account_id: "REC: cdd_receivable_account.id"
           user_id: "REF: base.user_admin"
 
+      - step: "Add a Line to CDD B Invoice (needed to stop at Open, not Done)"
+        action: "create"
+        model: "customer_invoice.line"
+        save_as: "cdd_b_invoice_line"
+        values:
+          customer_invoice_id: "REC: cdd_b_invoice.id"
+          name: "CDD B Invoice Line"
+          account_id: "REC: cdd_income_account.id"
+          uom_quantity: 1.0
+          price_unit: 1000000.0
+
       - step: "B: confirm the invoice"
         action: "call"
         target: "cdd_b_invoice"
@@ -771,6 +804,17 @@ scenarios:
           receivable_account_id: "REC: cdd_receivable_account.id"
           user_id: "REF: base.user_admin"
 
+      - step: "Add a Line to CDD C Invoice 1 (needed to stop at Open, not Done)"
+        action: "create"
+        model: "customer_invoice.line"
+        save_as: "cdd_c_invoice1_line"
+        values:
+          customer_invoice_id: "REC: cdd_c_invoice1.id"
+          name: "CDD C Invoice 1 Line"
+          account_id: "REC: cdd_income_account.id"
+          uom_quantity: 1.0
+          price_unit: 1000000.0
+
       - step: "C: confirm the Term 1 invoice"
         action: "call"
         target: "cdd_c_invoice1"
@@ -831,6 +875,17 @@ scenarios:
           journal_id: "REC: cdd_journal.id"
           receivable_account_id: "REC: cdd_receivable_account.id"
           user_id: "REF: base.user_admin"
+
+      - step: "Add a Line to CDD C Invoice 2 (needed to stop at Open, not Done)"
+        action: "create"
+        model: "customer_invoice.line"
+        save_as: "cdd_c_invoice2_line"
+        values:
+          customer_invoice_id: "REC: cdd_c_invoice2.id"
+          name: "CDD C Invoice 2 Line"
+          account_id: "REC: cdd_income_account.id"
+          uom_quantity: 1.0
+          price_unit: 1000000.0
 
       - step: "C: confirm the Term 2 invoice"
         action: "call"

--- a/ssi_school_scholarship_deduction/tests/test_data_school_scholarship_award_create_due_deduction.yaml
+++ b/ssi_school_scholarship_deduction/tests/test_data_school_scholarship_award_create_due_deduction.yaml
@@ -40,6 +40,11 @@ scenarios:
           code: "CDDTM"
           date_start: 2026-07-01
           date_end: 2026-12-31
+          # Required before the enrollment using this term can ever
+          # reach "open" -- school_enrollment._check_enrollment_window
+          # rejects opening an enrollment whose term is not itself
+          # open for enrollment.
+          enrollment_state: "open"
           year_id: "REC: cdd_academic_year.id"
 
       - step: "Create the grade"
@@ -98,6 +103,10 @@ scenarios:
         target: "cdd_enrollment"
         method: "action_confirm"
         as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
 
       - step: "Approve the enrollment as admin (opens it)"
         action: "call"

--- a/ssi_school_scholarship_deduction/tests/test_school_scholarship_award_create_due_deduction.py
+++ b/ssi_school_scholarship_deduction/tests/test_school_scholarship_award_create_due_deduction.py
@@ -1,0 +1,197 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestSchoolScholarshipAwardCreateDueDeduction(YamlTransactionCase):
+    """Scenario tests for the Create Due Deduction feature added to
+    ``school_scholarship_award`` by this glue module -- grouping by
+    invoice, skipping not-yet-due Schedule lines, idempotency once a
+    Deduction opens, and the wizard's own multi-Award and negative
+    paths.
+    """
+
+    def test_award_create_due_deduction(self):
+        """Run the create due deduction scenario.
+
+        Covers ``_get_due_schedule``/``_create_due_deduction`` on the
+        Award, and the ``create_due_scholarship_deduction`` wizard's
+        multi-Award and negative (``UserError``) paths.
+        """
+        self.run_yaml_scenario(
+            "test_data_school_scholarship_award_create_due_deduction.yaml"
+        )
+
+    def test_action_open_create_due_deduction_wizard_returns_action(self):
+        """Assert the action dict returned when opening the wizard.
+
+        Pure Python -- trigger P1 (L-01: ``action: call`` discards the
+        method's return value, and L-02: the "actual" side of every
+        YAML assert is always a ``getattr`` on a record, never a bare
+        dict). Run against a recordset of *two* Awards -- rather than
+        one -- to also demonstrate that ``active_ids`` carries every
+        selected Award, the same code path exercised when the button
+        is clicked from several rows selected in the list view.
+        """
+        grade_type = self.env["school_grade_type"].create(
+            {
+                "name": "P1 Grade Type",
+                "code": "P1GT",
+            }
+        )
+        school = self.env["school"].create(
+            {
+                "name": "P1 School",
+                "code": "P1SC",
+                "grade_type_id": grade_type.id,
+            }
+        )
+        academic_year = self.env["school_academic_year"].create(
+            {
+                "name": "P1 Academic Year",
+                "code": "P1AY",
+                "date_start": "2026-07-01",
+                "date_end": "2027-06-30",
+            }
+        )
+        academic_term = self.env["school_academic_term"].create(
+            {
+                "name": "P1 Academic Term",
+                "code": "P1TM",
+                "date_start": "2026-07-01",
+                "date_end": "2026-12-31",
+                "year_id": academic_year.id,
+            }
+        )
+        grade = self.env["school_grade"].create(
+            {
+                "name": "P1 Grade",
+                "code": "P1GR",
+                "type_id": grade_type.id,
+            }
+        )
+        grade_class = self.env["school_grade_class"].create(
+            {
+                "name": "P1 Grade Class",
+                "code": "P1CL",
+                "school_id": school.id,
+                "grade_id": grade.id,
+            }
+        )
+        contact = self.env["res.partner"].create(
+            {
+                "name": "P1 Contact",
+            }
+        )
+        student = self.env["school_student"].create(
+            {
+                "name": "P1 Student",
+                "code": "P1ST",
+                "contact_id": contact.id,
+                "school_id": school.id,
+            }
+        )
+        enrollment = self.env["school_enrollment"].create(
+            {
+                "academic_year_id": academic_year.id,
+                "academic_term_id": academic_term.id,
+                "school_id": school.id,
+                "grade_id": grade.id,
+                "grade_class_id": grade_class.id,
+                "student_id": student.id,
+            }
+        )
+        account_type_income = self.env.ref("account.data_account_type_revenue")
+        discount_account = self.env["account.account"].create(
+            {
+                "name": "P1 Discount Account",
+                "code": "P1DA",
+                "user_type_id": account_type_income.id,
+                "reconcile": False,
+            }
+        )
+        journal = self.env["account.journal"].create(
+            {
+                "name": "P1 Journal",
+                "code": "JP1",
+                "type": "sale",
+            }
+        )
+        scholarship_type = self.env["school_scholarship_type"].create(
+            {
+                "name": "P1 Type",
+                "code": "P1TY",
+                "deduction_journal_id": journal.id,
+                "discount_account_id": discount_account.id,
+            }
+        )
+        product = self.env["product.product"].create(
+            {
+                "name": "P1 Product",
+                "type": "service",
+            }
+        )
+        # ``scope_ids`` is required -- an empty Program fails
+        # ``_check_scope_ids`` (forced explicitly in ``create()`` even
+        # when this key is entirely absent from ``vals``).
+        program = self.env["school_scholarship_program"].create(
+            {
+                "name": "P1 Program",
+                "code": "P1PRG",
+                "type_id": scholarship_type.id,
+                "school_id": school.id,
+                "academic_year_id": academic_year.id,
+                "deduction_journal_id": journal.id,
+                "discount_account_id": discount_account.id,
+                "scope_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "scope_basis": "product",
+                            "product_id": product.id,
+                            "benefit_type": "fee_reduction",
+                            "computation": "percentage",
+                            "percentage": 40.0,
+                        },
+                    )
+                ],
+            }
+        )
+        award_1 = self.env["school_scholarship_award"].create(
+            {
+                "program_id": program.id,
+                "student_id": student.id,
+                "enrollment_id": enrollment.id,
+                "date_start": "2026-07-01",
+                "date_end": "2026-12-31",
+            }
+        )
+        award_2 = self.env["school_scholarship_award"].create(
+            {
+                "program_id": program.id,
+                "student_id": student.id,
+                "enrollment_id": enrollment.id,
+                "date_start": "2026-07-01",
+                "date_end": "2026-12-31",
+            }
+        )
+        awards = award_1 | award_2
+
+        # ``bypass_policy_check`` skips ``create_deduction_ok`` -- that
+        # policy gate is exercised by the wizard's own negative-path
+        # scenario in YAML; this method only asserts the shape of the
+        # returned action dict.
+        action = awards.with_context(
+            bypass_policy_check=True
+        ).action_open_create_due_deduction_wizard()
+
+        self.assertEqual(action["type"], "ir.actions.act_window")
+        self.assertEqual(action["target"], "new")
+        self.assertEqual(action["res_model"], "create_due_scholarship_deduction")
+        self.assertEqual(sorted(action["context"]["active_ids"]), sorted(awards.ids))

--- a/ssi_school_scholarship_deduction/tests/test_ui_school_scholarship_award_create_due_deduction.py
+++ b/ssi_school_scholarship_deduction/tests/test_ui_school_scholarship_award_create_due_deduction.py
@@ -1,0 +1,298 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+# HttpSavepointCase -- NOT HttpCase. In 14.0, HttpCase does not set up
+# cls.env in setUpClass, so fixtures written there would fail with
+# AttributeError before the browser even starts.
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiSchoolScholarshipAwardCreateDueDeduction(HttpSavepointCase):
+    """Tour test for the Create Due Deduction work instruction, added
+    to ``school_scholarship_award`` by this glue module.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Create an Award with one due, invoiced Schedule line."""
+        super().setUpClass()
+        admin = cls.env.ref("base.user_admin")
+        account_type_income = cls.env.ref("account.data_account_type_revenue")
+        account_type_receivable = cls.env.ref("account.data_account_type_receivable")
+
+        # Pre-Condition -- School/Academic Year/Grade/Grade
+        # Class/Student, so an Enrollment can be created for the tour
+        # Student.
+        tour_grade_type = cls.env["school_grade_type"].create(
+            {
+                "name": "TOUR CDD Grade Type",
+                "code": "TOURCDDGT",
+            }
+        )
+        tour_school = cls.env["school"].create(
+            {
+                "name": "TOUR CDD School",
+                "code": "TOURCDDS",
+                "grade_type_id": tour_grade_type.id,
+            }
+        )
+        tour_academic_year = cls.env["school_academic_year"].create(
+            {
+                "name": "TOUR CDD Academic Year",
+                "code": "TOURCDDY",
+                "date_start": "2026-07-01",
+                "date_end": "2027-06-30",
+            }
+        )
+        tour_academic_term = cls.env["school_academic_term"].create(
+            {
+                "name": "TOUR CDD Academic Term",
+                "code": "TOURCDDTM",
+                "date_start": "2026-07-01",
+                "date_end": "2026-12-31",
+                "year_id": tour_academic_year.id,
+            }
+        )
+        tour_grade = cls.env["school_grade"].create(
+            {
+                "name": "TOUR CDD Grade",
+                "code": "TOURCDDG",
+                "type_id": tour_grade_type.id,
+            }
+        )
+        tour_grade_class = cls.env["school_grade_class"].create(
+            {
+                "name": "TOUR CDD Grade Class",
+                "code": "TOURCDDGC",
+                "school_id": tour_school.id,
+                "grade_id": tour_grade.id,
+            }
+        )
+        tour_contact = cls.env["res.partner"].create(
+            {
+                "name": "TOUR CDD Student Contact",
+            }
+        )
+        tour_student = cls.env["school_student"].create(
+            {
+                "name": "TOUR CDD Student",
+                "code": "TOURCDDST",
+                "contact_id": tour_contact.id,
+                "school_id": tour_school.id,
+            }
+        )
+        tour_enrollment = cls.env["school_enrollment"].create(
+            {
+                "name": "TOUR-CDD-ENR-001",
+                "academic_year_id": tour_academic_year.id,
+                "academic_term_id": tour_academic_term.id,
+                "school_id": tour_school.id,
+                "grade_id": tour_grade.id,
+                "grade_class_id": tour_grade_class.id,
+                "student_id": tour_student.id,
+            }
+        )
+        # Confirm/Approve so payment_term._compute_state can ever read
+        # "invoiced" -- it only does so once its own enrollment_id.state
+        # is "open" or "done" (odoo-school-scholarship,
+        # school_enrollment_payment_term.py, _compute_state). Run as
+        # admin for both steps, mirroring ssi_school's own
+        # test_data_enrollment_create_due_invoice.yaml.
+        tour_enrollment.with_user(admin).action_confirm()
+        tour_enrollment.invalidate_cache()
+        tour_enrollment.with_user(admin).action_approve_approval()
+
+        # Pre-Condition -- a Funding Source, a Product, and a Program
+        # with one Fee Reduction Scope line, so the Award's Benefit
+        # and Funding tabs both have something to select.
+        tour_analytic_account = cls.env["account.analytic.account"].create(
+            {
+                "name": "TOUR CDD Analytic",
+            }
+        )
+        tour_funding_source = cls.env["school_scholarship_funding_source"].create(
+            {
+                "name": "TOUR CDD Funding Source",
+                "code": "TOURCDDF",
+                "analytic_account_id": tour_analytic_account.id,
+            }
+        )
+        tour_product = cls.env["product.product"].create(
+            {
+                "name": "TOUR CDD Product",
+                "type": "service",
+            }
+        )
+        tour_journal = cls.env["account.journal"].create(
+            {
+                "name": "TOUR CDD Sale Journal",
+                "code": "TCDDJ",
+                "type": "sale",
+            }
+        )
+        tour_receivable_account = cls.env["account.account"].create(
+            {
+                "name": "TOUR CDD Receivable Account",
+                "code": "TOURCDDRA",
+                "user_type_id": account_type_receivable.id,
+                "reconcile": True,
+            }
+        )
+        tour_discount_account = cls.env["account.account"].create(
+            {
+                "name": "TOUR CDD Discount Account",
+                "code": "TOURCDDDA",
+                "user_type_id": account_type_income.id,
+                "reconcile": False,
+            }
+        )
+        tour_income_account = cls.env["account.account"].create(
+            {
+                "name": "TOUR CDD Income Account",
+                "code": "TOURCDDIA",
+                "user_type_id": account_type_income.id,
+                "reconcile": False,
+            }
+        )
+        tour_invoice_type = cls.env["customer_invoice_type"].create(
+            {
+                "name": "TOUR CDD Invoice Type",
+                "code": "/",
+                "journal_id": tour_journal.id,
+                "receivable_account_id": tour_receivable_account.id,
+            }
+        )
+        tour_type = cls.env["school_scholarship_type"].create(
+            {
+                "name": "TOUR CDD Scholarship Type",
+                "code": "TOURCDDTY",
+                "deduction_journal_id": tour_journal.id,
+                "discount_account_id": tour_discount_account.id,
+            }
+        )
+        tour_program = cls.env["school_scholarship_program"].create(
+            {
+                "name": "TOUR CDD Program",
+                "code": "TOURCDDPRG",
+                "type_id": tour_type.id,
+                "school_id": tour_school.id,
+                "academic_year_id": tour_academic_year.id,
+                "funding_source_ids": [(6, 0, [tour_funding_source.id])],
+                "deduction_journal_id": tour_journal.id,
+                "discount_account_id": tour_discount_account.id,
+                "scope_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "scope_basis": "product",
+                            "product_id": tour_product.id,
+                            "benefit_type": "fee_reduction",
+                            "computation": "percentage",
+                            "percentage": 40.0,
+                        },
+                    )
+                ],
+            }
+        )
+
+        # Pre-Condition -- one Payment Term already invoiced and open,
+        # so its own Schedule line is due.
+        tour_term = cls.env["school_enrollment_payment_term"].create(
+            {
+                "enrollment_id": tour_enrollment.id,
+                "name": "TOUR CDD Term",
+                "date_invoice": "2026-08-01",
+                "detail_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": tour_product.id,
+                            "name": "TOUR CDD Term Fee",
+                            "account_id": tour_income_account.id,
+                            "uom_quantity": 1.0,
+                            "uom_id": cls.env.ref("uom.product_uom_unit").id,
+                            "price_unit": 1000000.0,
+                        },
+                    )
+                ],
+            }
+        )
+        tour_invoice = cls.env["customer_invoice"].create(
+            {
+                "name": "TOUR-CDD-INV-001",
+                "type_id": tour_invoice_type.id,
+                "partner_id": tour_contact.id,
+                "date": "2026-08-01",
+                "date_due": "2026-08-15",
+                "currency_id": cls.env.company.currency_id.id,
+                "journal_id": tour_journal.id,
+                "receivable_account_id": tour_receivable_account.id,
+                "user_id": admin.id,
+            }
+        )
+        tour_invoice.action_confirm()
+        tour_invoice.invalidate_cache()
+        tour_invoice.with_user(admin).action_approve_approval()
+        tour_term.write({"customer_invoice_id": tour_invoice.id})
+
+        # Pre-Condition -- the Award whose form the tour opens, with a
+        # Fee Reduction Benefit line matching TOUR CDD Product, and a
+        # Funding line at 100%.
+        cls.tour_award = cls.env["school_scholarship_award"].create(
+            {
+                "name": "TOUR-AWARD-CREATEDEDUCTION-001",
+                "program_id": tour_program.id,
+                "student_id": tour_student.id,
+                "enrollment_id": tour_enrollment.id,
+                "date_start": "2026-07-01",
+                "date_end": "2026-12-31",
+                "discount_account_id": tour_discount_account.id,
+                "deduction_journal_id": tour_journal.id,
+                "user_id": admin.id,
+                "benefit_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "TOUR CDD Benefit",
+                            "product_id": tour_product.id,
+                            "percentage": 40.0,
+                        },
+                    )
+                ],
+                "funding_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "funding_source_id": tour_funding_source.id,
+                            "percentage": 100.0,
+                        },
+                    )
+                ],
+            }
+        )
+        tour_benefit = cls.tour_award.benefit_ids[:1]
+        cls.env["school_scholarship_award_schedule"].create(
+            {
+                "benefit_id": tour_benefit.id,
+                "payment_term_id": tour_term.id,
+                "date": tour_term.date_invoice,
+                "state": "scheduled",
+            }
+        )
+
+    def test_create_due_deduction(self):
+        """Run the create due deduction tour for ``school_scholarship_award``.
+
+        IK: docs/school_scholarship_award/07-create-due-deduction.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_school_scholarship_deduction_school_scholarship_award_create_due_deduction",
+            login="admin",
+        )

--- a/ssi_school_scholarship_deduction/tests/test_ui_school_scholarship_award_create_due_deduction.py
+++ b/ssi_school_scholarship_deduction/tests/test_ui_school_scholarship_award_create_due_deduction.py
@@ -240,6 +240,19 @@ class TestUiSchoolScholarshipAwardCreateDueDeduction(HttpSavepointCase):
                 "user_id": admin.id,
             }
         )
+        # Without a Line, ``move_id`` is never created and
+        # ``customer_invoice._20_skip_open`` jumps this document
+        # straight from Confirm to Done -- it never stops at Open at
+        # all (odoo-school-scholarship-deduction PR #25 CI finding).
+        cls.env["customer_invoice.line"].create(
+            {
+                "customer_invoice_id": tour_invoice.id,
+                "name": "TOUR CDD Invoice Line",
+                "account_id": tour_income_account.id,
+                "uom_quantity": 1,
+                "price_unit": 1000000.0,
+            }
+        )
         tour_invoice.action_confirm()
         tour_invoice.invalidate_cache()
         tour_invoice.with_user(admin).action_approve_approval()
@@ -282,15 +295,15 @@ class TestUiSchoolScholarshipAwardCreateDueDeduction(HttpSavepointCase):
                 ],
             }
         )
-        tour_benefit = cls.tour_award.benefit_ids[:1]
-        cls.env["school_scholarship_award_schedule"].create(
-            {
-                "benefit_id": tour_benefit.id,
-                "payment_term_id": tour_term.id,
-                "date": tour_term.date_invoice,
-                "state": "scheduled",
-            }
-        )
+        # Confirm/Approve so the Award reaches Open -- the state the
+        # Create Due Deduction button's own policy requires
+        # (create_deduction_ok) -- which also auto-generates one
+        # Schedule line for the Term above via the award's own
+        # post_open hook (_10_generate_schedule), so no manual
+        # Schedule create() is needed here.
+        cls.tour_award.action_confirm()
+        cls.tour_award.invalidate_cache()
+        cls.tour_award.with_user(admin).action_approve_approval()
 
     def test_create_due_deduction(self):
         """Run the create due deduction tour for ``school_scholarship_award``.

--- a/ssi_school_scholarship_deduction/tests/test_ui_school_scholarship_award_create_due_deduction.py
+++ b/ssi_school_scholarship_deduction/tests/test_ui_school_scholarship_award_create_due_deduction.py
@@ -53,6 +53,12 @@ class TestUiSchoolScholarshipAwardCreateDueDeduction(HttpSavepointCase):
                 "date_start": "2026-07-01",
                 "date_end": "2026-12-31",
                 "year_id": tour_academic_year.id,
+                # Required before the enrollment using this term can
+                # ever reach "open" --
+                # school_enrollment._check_enrollment_window rejects
+                # opening an enrollment whose term is not itself open
+                # for enrollment.
+                "enrollment_state": "open",
             }
         )
         tour_grade = cls.env["school_grade"].create(

--- a/ssi_school_scholarship_deduction/views/assets.xml
+++ b/ssi_school_scholarship_deduction/views/assets.xml
@@ -13,6 +13,10 @@
                 type="text/javascript"
                 src="/ssi_school_scholarship_deduction/static/tests/tours/school_scholarship_deduction_tour.js"
             />
+        <script
+                type="text/javascript"
+                src="/ssi_school_scholarship_deduction/static/tests/tours/school_scholarship_award_create_due_deduction_tour.js"
+            />
     </xpath>
 </template>
 </odoo>

--- a/ssi_school_scholarship_deduction/views/school_scholarship_award.xml
+++ b/ssi_school_scholarship_deduction/views/school_scholarship_award.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+<record id="school_scholarship_award_view_form_create_due_deduction" model="ir.ui.view">
+    <field name="name">school_scholarship_award form - create due deduction</field>
+    <field name="model">school_scholarship_award</field>
+    <field
+            name="inherit_id"
+            ref="ssi_school_scholarship.school_scholarship_award_view_form"
+        />
+    <field name="arch" type="xml">
+        <data>
+            <xpath expr="//header" position="inside">
+                <field name="create_deduction_ok" invisible="1" />
+                <button
+                        name="action_open_create_due_deduction_wizard"
+                        type="object"
+                        string="Create Due Deduction"
+                        attrs="{'invisible': [('create_deduction_ok', '=', False)]}"
+                    />
+            </xpath>
+        </data>
+    </field>
+</record>
+
+<record id="school_scholarship_award_view_tree_create_due_deduction" model="ir.ui.view">
+    <field name="name">school_scholarship_award tree - create due deduction</field>
+    <field name="model">school_scholarship_award</field>
+    <field
+            name="inherit_id"
+            ref="ssi_school_scholarship.school_scholarship_award_view_tree"
+        />
+    <field name="arch" type="xml">
+        <data>
+            <xpath expr="//header" position="inside">
+                <button
+                        name="action_open_create_due_deduction_wizard"
+                        type="object"
+                        string="Create Due Deduction"
+                    />
+            </xpath>
+        </data>
+    </field>
+</record>
+</odoo>

--- a/ssi_school_scholarship_deduction/wizards/__init__.py
+++ b/ssi_school_scholarship_deduction/wizards/__init__.py
@@ -2,7 +2,4 @@
 # Copyright 2026 PT. Simetri Sinergi Indonesia
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from . import (  # noqa: F401
-    models,
-    wizards,
-)
+from . import create_due_scholarship_deduction  # noqa: F401

--- a/ssi_school_scholarship_deduction/wizards/create_due_scholarship_deduction.py
+++ b/ssi_school_scholarship_deduction/wizards/create_due_scholarship_deduction.py
@@ -1,0 +1,124 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
+
+
+class CreateDueScholarshipDeduction(models.TransientModel):
+    """
+    Wizard that realizes every due Schedule line of one or more
+    Scholarship Awards -- selected from the Award's own form or from
+    several Awards selected in the list view -- into draft
+    ``school_scholarship_deduction`` documents. Delegates the actual
+    realization, Award by Award, to
+    ``school_scholarship_award._create_due_deduction``.
+    """
+
+    _name = "create_due_scholarship_deduction"
+    _description = "Create Due Scholarship Deduction"
+
+    award_ids = fields.Many2many(
+        string="Awards",
+        comodel_name="school_scholarship_award",
+        relation="rel_create_due_scholarship_deduction_award",
+        column1="wizard_id",
+        column2="award_id",
+        readonly=True,
+        help="Awards whose due Schedule lines will be realized into "
+        "Deduction documents.",
+    )
+    date_start = fields.Date(
+        string="Date Start",
+        help="Earliest Schedule Date to process. Leave empty for no " "lower bound.",
+    )
+    date_end = fields.Date(
+        string="Date End",
+        required=True,
+        help="Latest Schedule Date to process.",
+    )
+
+    @api.model
+    def default_get(self, fields_list):
+        """Prefill Awards from the form or list view selection.
+
+        :param fields_list: field names requested by the client
+        :return: dict of default values
+        """
+        res = super().default_get(fields_list)
+        if self.env.context.get("active_model") == "school_scholarship_award":
+            active_ids = self.env.context.get("active_ids", [])
+            res["award_ids"] = [(6, 0, active_ids)]
+        return res
+
+    def action_create_due_deduction(self):
+        """Realize the selected Awards' due Schedule lines.
+
+        :return: an ``ir.actions.act_window`` dict listing the newly
+            created ``school_scholarship_deduction`` documents
+        """
+        for record in self.sudo():
+            result = record._create_due_deduction()
+        return result
+
+    def _create_due_deduction(self):
+        """Realize every selected Award's due Schedule lines.
+
+        Delegates to each Award's own ``_create_due_deduction``, then
+        opens the resulting documents. Raises when nothing at all was
+        created across every selected Award, since that usually means
+        the target period has not been invoiced yet.
+
+        :return: an ``ir.actions.act_window`` dict opening the newly
+            created ``school_scholarship_deduction`` documents
+        :raises UserError: when no Deduction document was created for
+            any of the selected Awards
+        """
+        self.ensure_one()
+        deductions = self.env["school_scholarship_deduction"]
+        for award in self.award_ids:
+            deductions |= award._create_due_deduction(self.date_start, self.date_end)
+        self._check_deductions(deductions)
+        return self._open_deductions(deductions)
+
+    def _check_deductions(self, deductions):
+        """Reject a run that created no Deduction document at all.
+
+        :param deductions: the ``school_scholarship_deduction``
+            recordset created by this run
+        :raises UserError: when ``deductions`` is empty
+        """
+        self.ensure_one()
+        if not deductions:
+            error_message = (
+                _(
+                    """
+Context: Create due scholarship deduction
+Database ID: %s
+Problem: No Deduction document was created for the selected Award(s)
+Solution: Check that the period's invoice has already been issued
+"""
+                )
+                % (self.id,)
+            )
+            raise UserError(error_message)
+
+    def _open_deductions(self, deductions):
+        """Build the window action listing the newly created documents.
+
+        :param deductions: the ``school_scholarship_deduction``
+            recordset just created
+        :return: an ``ir.actions.act_window`` dict
+        """
+        self.ensure_one()
+        waction = self.env.ref(
+            "ssi_school_scholarship_deduction.school_scholarship_deduction_action"
+        ).read()[0]
+        waction.update(
+            {
+                "view_mode": "tree,form",
+                "domain": [("id", "in", deductions.ids)],
+            }
+        )
+        return waction

--- a/ssi_school_scholarship_deduction/wizards/create_due_scholarship_deduction.xml
+++ b/ssi_school_scholarship_deduction/wizards/create_due_scholarship_deduction.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+<record id="create_due_scholarship_deduction_view_form" model="ir.ui.view">
+    <field name="name">create_due_scholarship_deduction - form</field>
+    <field name="model">create_due_scholarship_deduction</field>
+    <field name="arch" type="xml">
+        <form string="Create Due Scholarship Deduction">
+            <group name="main" colspan="4" col="2">
+                <field
+                        name="award_ids"
+                        widget="many2many_tags"
+                        colspan="2"
+                        invisible="1"
+                    />
+                <field name="date_start" />
+                <field name="date_end" />
+            </group>
+            <footer>
+                <button
+                        name="action_create_due_deduction"
+                        type="object"
+                        string="Create Due Deduction"
+                        class="btn-primary"
+                    />
+                <button string="Cancel" class="btn-default" special="cancel" />
+            </footer>
+        </form>
+    </field>
+</record>
+
+<record id="create_due_scholarship_deduction_action" model="ir.actions.act_window">
+    <field name="name">Create Due Scholarship Deduction</field>
+    <field name="type">ir.actions.act_window</field>
+    <field name="res_model">create_due_scholarship_deduction</field>
+    <field name="view_mode">form</field>
+    <field name="target">new</field>
+</record>
+</odoo>


### PR DESCRIPTION
## Ringkasan

Menambahkan wizard massal "Create Due Deduction" pada `school_scholarship_award`
(modul `ssi_school_scholarship_deduction`) untuk menerbitkan dokumen potongan
beasiswa dari jadwal yang sudah jatuh tempo — tanpa pernah bisa mendahului
tagihannya.

* `_get_due_schedule()` / `_create_due_deduction()` pada `school_scholarship_award`
  (glue): jadwal dianggap jatuh tempo hanya bila payment term-nya `invoiced` dan
  invoice-nya `open`; dikelompokkan per invoice, satu dokumen potongan `draft` per
  kelompok.
- `action_open_create_due_deduction_wizard()` ber-policy `create_deduction_ok`,
  tombol di form maupun list view award.
- Wizard `create_due_scholarship_deduction`, bisa dijalankan massal dari beberapa
  award terpilih.
- IK `docs/school_scholarship_award/07-create-due-deduction.md`, tour, dan unit
  test skenario YAML.

## Test plan

- [x] `assets/verify-module.sh` → `LOLOS: 0 ERROR`
- [x] `validate-ik.sh` → `LOLOS: 0 ERROR`
- [x] `validate-tour.sh` → `LOLOS: 0 ERROR`
- [x] `validate-unit-test.sh` (vs-head) → `0 ERROR baru, 0 peringatan baru`
- [ ] CI GitHub hijau

Closes #9