### PR TITLE
[UPD] ssi_school_scholarship_deduction - Pisahkan penyelesaian tagihan oleh beasiswa dari setoran kas

### DIFF
--- a/ssi_school_scholarship_deduction/__manifest__.py
+++ b/ssi_school_scholarship_deduction/__manifest__.py
@@ -15,6 +15,7 @@
     "installable": True,
     "application": False,
     "depends": [
+        "ssi_school",
         "ssi_school_scholarship",
         "ssi_customer_invoice",
         "ssi_accounting_entry_mixin",
@@ -46,6 +47,7 @@
         "views/school_scholarship_deduction.xml",
         "views/school_scholarship_deduction_recognition.xml",
         "views/school_scholarship_award.xml",
+        "views/customer_invoice.xml",
         "views/assets.xml",
     ],
 }

--- a/ssi_school_scholarship_deduction/models/__init__.py
+++ b/ssi_school_scholarship_deduction/models/__init__.py
@@ -10,3 +10,5 @@ from . import school_scholarship_deduction_line  # noqa: F401
 from . import school_scholarship_deduction_allocation  # noqa: F401
 from . import school_scholarship_deduction_recognition  # noqa: F401
 from . import school_scholarship_deduction_recognition_line  # noqa: F401
+from . import customer_invoice  # noqa: F401
+from . import school_enrollment_fee_analysis  # noqa: F401

--- a/ssi_school_scholarship_deduction/models/customer_invoice.py
+++ b/ssi_school_scholarship_deduction/models/customer_invoice.py
@@ -106,15 +106,11 @@ class CustomerInvoice(models.Model):
             amount_settled_by_scholarship = 0.0
             partials = record.receivable_move_line_id.matched_credit_ids
             if partials:
-                journal_ids = partials.mapped(
-                    "credit_move_id.move_id.journal_id"
-                ).ids
+                journal_ids = partials.mapped("credit_move_id.move_id.journal_id").ids
                 scholarship_journal_ids = (
                     Deduction.sudo()
                     .search(
-                        record._get_scholarship_deduction_journal_criteria(
-                            journal_ids
-                        )
+                        record._get_scholarship_deduction_journal_criteria(journal_ids)
                     )
                     .mapped("journal_id")
                     .ids
@@ -160,9 +156,7 @@ class CustomerInvoice(models.Model):
             allocations = Allocation.sudo().search(
                 record._get_scholarship_deduction_allocation_criteria()
             )
-            record.scholarship_deduction_ids = allocations.mapped(
-                "deduction_id"
-            ).ids
+            record.scholarship_deduction_ids = allocations.mapped("deduction_id").ids
 
     def _get_scholarship_deduction_allocation_criteria(self):
         """Build the domain selecting this invoice's own allocations.

--- a/ssi_school_scholarship_deduction/models/customer_invoice.py
+++ b/ssi_school_scholarship_deduction/models/customer_invoice.py
@@ -1,0 +1,176 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models
+
+
+class CustomerInvoice(models.Model):
+    """
+    Splits how much of a customer invoice's Realized Amount was
+    settled by a scholarship deduction versus an actual cash
+    deposit.
+
+    ``amount_realized`` alone cannot tell the two apart: a
+    scholarship deduction reconciles the same receivable journal
+    item a bank deposit would, so an invoice fully covered by a
+    scholarship reports itself as fully Realized -- and eventually
+    Paid -- without a single unit of cash ever moving. Cash receipt
+    reports built directly on ``amount_realized`` would then
+    overstate actual deposits. The distinction is read from the
+    journal of the reconciled credit's own move: a scholarship
+    journal is recognized by cross-checking it against the
+    ``journal_id`` actually used by ``school_scholarship_deduction``
+    documents, never by a hard-coded journal name.
+    """
+
+    _name = "customer_invoice"
+    _inherit = [
+        "customer_invoice",
+    ]
+
+    scholarship_deduction_ids = fields.Many2many(
+        string="Scholarship Deductions",
+        comodel_name="school_scholarship_deduction",
+        compute="_compute_scholarship_deduction_ids",
+        store=False,
+        compute_sudo=True,
+        help=(
+            "Scholarship deduction documents that allocate part of "
+            "their own Amount Total to this invoice, traced through "
+            "their own Allocation lines. Not stored -- always "
+            "reflects the current set of allocations."
+        ),
+    )
+    amount_settled_by_scholarship = fields.Monetary(
+        string="Settled by Scholarship",
+        compute="_compute_amount_settled",
+        store=True,
+        compute_sudo=True,
+        currency_field="currency_id",
+        help=(
+            "Portion of Realized Amount settled by scholarship "
+            "deductions rather than an actual cash deposit. Excluded "
+            "from Settled by Cash and from cash receipt reports."
+        ),
+    )
+    amount_settled_by_cash = fields.Monetary(
+        string="Settled by Cash",
+        compute="_compute_amount_settled",
+        store=True,
+        compute_sudo=True,
+        currency_field="currency_id",
+        help=(
+            "Realized Amount net of the portion settled by "
+            "scholarship. Cash receipt reports must use this field "
+            "instead of Realized Amount, or they overstate actual "
+            "deposits on invoices partly or fully covered by a "
+            "scholarship."
+        ),
+    )
+    has_scholarship = fields.Boolean(
+        string="Has Scholarship",
+        compute="_compute_amount_settled",
+        store=True,
+        compute_sudo=True,
+        help=(
+            "True once at least part of this invoice has been "
+            "settled by a scholarship deduction."
+        ),
+    )
+
+    @api.depends(
+        "receivable_move_line_id.matched_credit_ids",
+        "receivable_move_line_id.matched_credit_ids.amount",
+        "receivable_move_line_id.matched_credit_ids.credit_move_id.move_id.journal_id",
+        "amount_realized",
+    )
+    def _compute_amount_settled(self):
+        """Split Realized Amount into scholarship- and cash-settled.
+
+        Walks the receivable journal item's matched credits (the
+        ``account.partial.reconcile`` records where it is the debit
+        side) and sums the ``amount`` of every pair whose credit
+        move's own journal is used by at least one
+        ``school_scholarship_deduction`` document -- so the
+        scholarship journal is discovered from the deduction
+        documents that actually exist, never hard-coded by name.
+
+        :return: nothing; assigns ``amount_settled_by_scholarship``,
+            ``amount_settled_by_cash``, and ``has_scholarship``
+        """
+        Deduction = self.env[  # pylint: disable=invalid-name
+            "school_scholarship_deduction"
+        ]
+        for record in self:
+            amount_settled_by_scholarship = 0.0
+            partials = record.receivable_move_line_id.matched_credit_ids
+            if partials:
+                journal_ids = partials.mapped(
+                    "credit_move_id.move_id.journal_id"
+                ).ids
+                scholarship_journal_ids = (
+                    Deduction.sudo()
+                    .search(
+                        record._get_scholarship_deduction_journal_criteria(
+                            journal_ids
+                        )
+                    )
+                    .mapped("journal_id")
+                    .ids
+                )
+                for partial in partials:
+                    journal = partial.credit_move_id.move_id.journal_id
+                    if journal.id in scholarship_journal_ids:
+                        amount_settled_by_scholarship += partial.amount
+            record.amount_settled_by_scholarship = amount_settled_by_scholarship
+            record.amount_settled_by_cash = (
+                record.amount_realized - amount_settled_by_scholarship
+            )
+            record.has_scholarship = amount_settled_by_scholarship > 0.0
+
+    def _get_scholarship_deduction_journal_criteria(self, journal_ids):
+        """Build the domain identifying scholarship journals.
+
+        Extension point: override to change how a journal is
+        recognized as belonging to a scholarship deduction.
+
+        :param journal_ids: candidate ``account.journal`` ids, taken
+            from the receivable line's matched credits
+        :return: an Odoo search domain
+        """
+        self.ensure_one()
+        return [("journal_id", "in", journal_ids)]
+
+    def _compute_scholarship_deduction_ids(self):
+        """Trace the scholarship deductions allocated to this invoice.
+
+        No ``@api.depends``: the result is driven entirely by
+        ``school_scholarship_deduction_allocation`` records that
+        point at this invoice -- a relation with no field on this
+        model itself to declare as a dependency. ``store=False``
+        keeps the value fresh on every read instead.
+
+        :return: nothing; assigns ``scholarship_deduction_ids``
+        """
+        Allocation = self.env[  # pylint: disable=invalid-name
+            "school_scholarship_deduction_allocation"
+        ]
+        for record in self:
+            allocations = Allocation.sudo().search(
+                record._get_scholarship_deduction_allocation_criteria()
+            )
+            record.scholarship_deduction_ids = allocations.mapped(
+                "deduction_id"
+            ).ids
+
+    def _get_scholarship_deduction_allocation_criteria(self):
+        """Build the domain selecting this invoice's own allocations.
+
+        Extension point: override to broaden or narrow which
+        allocation lines count toward ``scholarship_deduction_ids``.
+
+        :return: an Odoo search domain
+        """
+        self.ensure_one()
+        return [("customer_invoice_id", "=", self.id)]

--- a/ssi_school_scholarship_deduction/models/school_enrollment_fee_analysis.py
+++ b/ssi_school_scholarship_deduction/models/school_enrollment_fee_analysis.py
@@ -1,0 +1,74 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class SchoolEnrollmentFeeAnalysis(models.Model):
+    """
+    Adds the scholarship/cash split to the fee analysis SQL view.
+
+    Wraps ``ssi_school``'s own query as a subquery and left-joins
+    ``customer_invoice`` on ``customer_invoice_id`` to expose, per
+    fee line, how much of its invoice's Realized Amount was covered
+    by a scholarship deduction versus an actual cash deposit --
+    letting pivot reports built on this view stop overstating cash
+    receipts on invoices partly or fully settled by scholarship.
+    """
+
+    _name = "school_enrollment_fee_analysis"
+    _inherit = [
+        "school_enrollment_fee_analysis",
+    ]
+
+    amount_scholarship = fields.Monetary(
+        string="Scholarship",
+        currency_field="currency_id",
+        readonly=True,
+        help=(
+            "Portion of the linked invoice's Realized Amount "
+            "settled by a scholarship deduction. Zero when the fee "
+            "line has no linked invoice yet."
+        ),
+    )
+    amount_gross = fields.Monetary(
+        string="Gross Realized",
+        currency_field="currency_id",
+        readonly=True,
+        help=(
+            "Realized Amount of the linked invoice, before splitting "
+            "off the scholarship-settled portion. Equal to "
+            "``amount_scholarship`` plus ``amount_net``."
+        ),
+    )
+    amount_net = fields.Monetary(
+        string="Net Cash",
+        currency_field="currency_id",
+        readonly=True,
+        help=(
+            "Realized Amount of the linked invoice net of the "
+            "scholarship-settled portion -- the figure fee analysis "
+            "reports should use as actual cash received."
+        ),
+    )
+
+    def _select_query(self):
+        """Left-join ``customer_invoice``'s scholarship split in.
+
+        :return: the SQL ``SELECT`` statement backing this view,
+            wrapping ``ssi_school``'s own query as a subquery
+        """
+        return """
+            SELECT
+                base.*,
+                COALESCE(ci.amount_settled_by_scholarship, 0.0)
+                    AS amount_scholarship,
+                COALESCE(ci.amount_realized, 0.0) AS amount_gross,
+                COALESCE(ci.amount_settled_by_cash, 0.0) AS amount_net
+            FROM (%s) base
+            LEFT JOIN customer_invoice ci
+                ON ci.id = base.customer_invoice_id
+        """ % (
+            super()._select_query()
+        )

--- a/ssi_school_scholarship_deduction/tests/__init__.py
+++ b/ssi_school_scholarship_deduction/tests/__init__.py
@@ -8,3 +8,4 @@ from . import test_school_scholarship_award_create_due_deduction  # noqa: F401
 from . import test_ui_school_scholarship_award_create_due_deduction  # noqa: F401
 from . import test_school_scholarship_deduction_recognition  # noqa: F401
 from . import test_ui_school_scholarship_deduction_recognition  # noqa: F401
+from . import test_customer_invoice_scholarship_deduction  # noqa: F401

--- a/ssi_school_scholarship_deduction/tests/test_customer_invoice_scholarship_deduction.py
+++ b/ssi_school_scholarship_deduction/tests/test_customer_invoice_scholarship_deduction.py
@@ -15,6 +15,4 @@ class TestCustomerInvoiceScholarshipDeduction(YamlTransactionCase):
         """Run the scholarship/cash split compute and negative-path
         scenarios for ``customer_invoice``.
         """
-        self.run_yaml_scenario(
-            "test_data_customer_invoice_scholarship_deduction.yaml"
-        )
+        self.run_yaml_scenario("test_data_customer_invoice_scholarship_deduction.yaml")

--- a/ssi_school_scholarship_deduction/tests/test_customer_invoice_scholarship_deduction.py
+++ b/ssi_school_scholarship_deduction/tests/test_customer_invoice_scholarship_deduction.py
@@ -1,0 +1,20 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestCustomerInvoiceScholarshipDeduction(YamlTransactionCase):
+    """Scenario tests for the ``customer_invoice`` scholarship split."""
+
+    def test_customer_invoice_scholarship_deduction(self):
+        """Run the scholarship/cash split compute and negative-path
+        scenarios for ``customer_invoice``.
+        """
+        self.run_yaml_scenario(
+            "test_data_customer_invoice_scholarship_deduction.yaml"
+        )

--- a/ssi_school_scholarship_deduction/tests/test_data_customer_invoice_scholarship_deduction.yaml
+++ b/ssi_school_scholarship_deduction/tests/test_data_customer_invoice_scholarship_deduction.yaml
@@ -535,15 +535,12 @@ scenarios:
       - step: "Find the deposit's own credit line on the receivable account"
         action: "search"
         model: "account.move.line"
-        domain:
-          [
-            ["move_id", "=", "REC: e2_bank_move.id"],
-            ["credit", "=", 600000.0],
-          ]
+        domain: [["move_id", "=", "REC: e2_bank_move.id"], ["credit", "=", 600000.0]]
         limit: 1
         save_as: "e2_bank_credit_line"
 
-      - step: "Combine the invoice's own receivable line with the deposit's own credit line"
+      - step:
+          "Combine the invoice's own receivable line with the deposit's own credit line"
         action: "search"
         model: "account.move.line"
         domain:
@@ -551,7 +548,10 @@ scenarios:
             [
               "id",
               "in",
-              ["REC: e2_invoice.receivable_move_line_id.id", "REC: e2_bank_credit_line.id"],
+              [
+                "REC: e2_invoice.receivable_move_line_id.id",
+                "REC: e2_bank_credit_line.id",
+              ],
             ],
           ]
         save_as: "e2_combined_lines"
@@ -877,14 +877,12 @@ scenarios:
         action: "search"
         model: "account.move.line"
         domain:
-          [
-            ["move_id", "=", "REC: e4_own_bank_move.id"],
-            ["credit", "=", 1000000.0],
-          ]
+          [["move_id", "=", "REC: e4_own_bank_move.id"], ["credit", "=", 1000000.0]]
         limit: 1
         save_as: "e4_own_credit_line"
 
-      - step: "Combine the invoice's own receivable line with the deposit's own credit line"
+      - step:
+          "Combine the invoice's own receivable line with the deposit's own credit line"
         action: "search"
         model: "account.move.line"
         domain:
@@ -1005,10 +1003,7 @@ scenarios:
         action: "search"
         model: "account.move.line"
         domain:
-          [
-            ["move_id", "=", "REC: e4_sponsor_bank_move.id"],
-            ["credit", "=", 1000000.0],
-          ]
+          [["move_id", "=", "REC: e4_sponsor_bank_move.id"], ["credit", "=", 1000000.0]]
         limit: 1
         save_as: "e4_sponsor_credit_line"
 

--- a/ssi_school_scholarship_deduction/tests/test_data_customer_invoice_scholarship_deduction.yaml
+++ b/ssi_school_scholarship_deduction/tests/test_data_customer_invoice_scholarship_deduction.yaml
@@ -1,272 +1,88 @@
-setup:
-  steps:
-    - step: "Create the grade type"
-      action: "create"
-      model: "school_grade_type"
-      save_as: "s_grade_type"
-      values:
-        name: "S Grade Type"
-        code: "SGT"
-
-    - step: "Create the school"
-      action: "create"
-      model: "school"
-      save_as: "s_school"
-      values:
-        name: "S School"
-        code: "SSC"
-        grade_type_id: "REC: s_grade_type.id"
-
-    - step: "Create the academic year"
-      action: "create"
-      model: "school_academic_year"
-      save_as: "s_academic_year"
-      values:
-        name: "S Academic Year"
-        code: "SAY"
-        date_start: 2026-07-01
-        date_end: 2027-06-30
-
-    - step: "Create the academic term"
-      action: "create"
-      model: "school_academic_term"
-      save_as: "s_academic_term"
-      values:
-        name: "S Term"
-        code: "STM"
-        date_start: 2026-07-01
-        date_end: 2026-12-31
-        year_id: "REC: s_academic_year.id"
-
-    - step: "Create the grade"
-      action: "create"
-      model: "school_grade"
-      save_as: "s_grade"
-      values:
-        name: "S Grade"
-        code: "SGR"
-        type_id: "REC: s_grade_type.id"
-
-    - step: "Create the grade class"
-      action: "create"
-      model: "school_grade_class"
-      save_as: "s_grade_class"
-      values:
-        name: "S Class"
-        code: "SCL"
-        school_id: "REC: s_school.id"
-        grade_id: "REC: s_grade.id"
-
-    - step: "Create the student contact"
-      action: "create"
-      model: "res.partner"
-      save_as: "s_contact"
-      values:
-        name: "S Contact"
-
-    - step: "Create a sponsor contact, unrelated to the student"
-      action: "create"
-      model: "res.partner"
-      save_as: "s_sponsor_contact"
-      values:
-        name: "S Sponsor Contact"
-
-    - step: "Create the student"
-      action: "create"
-      model: "school_student"
-      save_as: "s_student"
-      values:
-        name: "S Student"
-        code: "SST"
-        contact_id: "REC: s_contact.id"
-        school_id: "REC: s_school.id"
-
-    - step: "Create the enrollment"
-      action: "create"
-      model: "school_enrollment"
-      save_as: "s_enrollment"
-      values:
-        academic_year_id: "REC: s_academic_year.id"
-        academic_term_id: "REC: s_academic_term.id"
-        school_id: "REC: s_school.id"
-        grade_id: "REC: s_grade.id"
-        grade_class_id: "REC: s_grade_class.id"
-        student_id: "REC: s_student.id"
-
-    - step: "Create the analytic account for the funding source"
-      action: "create"
-      model: "account.analytic.account"
-      save_as: "s_analytic"
-      values:
-        name: "S Analytic"
-
-    - step: "Create the funding source"
-      action: "create"
-      model: "school_scholarship_funding_source"
-      save_as: "s_funding_source"
-      values:
-        name: "S Funding Source"
-        code: "SFS"
-        analytic_account_id: "REC: s_analytic.id"
-
-    - step: "Create the product covered by the benefit lines"
-      action: "create"
-      model: "product.product"
-      save_as: "s_product"
-      values:
-        name: "S Product"
-        type: "service"
-
-    # ── Three DIFFERENT journals, so the compute's own journal-based
-    # split is genuinely exercised: the sales journal only ever posts
-    # the invoice's own move, the scholarship journal only ever posts
-    # deduction documents, and the bank journal only ever posts plain
-    # cash-deposit journal entries that must NEVER be mistaken for a
-    # scholarship. ──────────────────────────────────────────────────
-    - step: "Create the sales journal used by the invoice's own move"
-      action: "create"
-      model: "account.journal"
-      save_as: "s_invoice_journal"
-      values:
-        name: "S Invoice Journal"
-        code: "SIJ"
-        type: "sale"
-
-    - step: "Create the journal used by scholarship deduction documents"
-      action: "create"
-      model: "account.journal"
-      save_as: "s_scholarship_journal"
-      values:
-        name: "S Scholarship Journal"
-        code: "SSJ"
-        type: "general"
-
-    - step: "Create the bank journal used by plain cash deposits"
-      action: "create"
-      model: "account.journal"
-      save_as: "s_bank_journal"
-      values:
-        name: "S Bank Journal"
-        code: "SBJ"
-        type: "bank"
-
-    - step: "Get the account.account.type Income reference"
-      action: "ref"
-      xml_id: "account.data_account_type_revenue"
-      save_as: "account_type_income"
-
-    - step: "Get the account.account.type Receivable reference"
-      action: "ref"
-      xml_id: "account.data_account_type_receivable"
-      save_as: "account_type_receivable"
-
-    - step: "Get the account.account.type Liquidity reference"
-      action: "ref"
-      xml_id: "account.data_account_type_liquidity"
-      save_as: "account_type_liquidity"
-
-    - step: "Create the receivable account shared by invoices and deductions"
-      action: "create"
-      model: "account.account"
-      save_as: "s_receivable_account"
-      values:
-        name: "S Receivable Account"
-        code: "SRA"
-        user_type_id: "REC: account_type_receivable.id"
-        reconcile: true
-
-    - step: "Create the discount account the deduction lines post to"
-      action: "create"
-      model: "account.account"
-      save_as: "s_discount_account"
-      values:
-        name: "S Discount Account"
-        code: "SDA"
-        user_type_id: "REC: account_type_income.id"
-        reconcile: false
-
-    - step: "Create the income account the invoice lines post to"
-      action: "create"
-      model: "account.account"
-      save_as: "s_income_account"
-      values:
-        name: "S Income Account"
-        code: "SIA"
-        user_type_id: "REC: account_type_income.id"
-        reconcile: false
-
-    - step: "Create the bank account the cash deposits debit"
-      action: "create"
-      model: "account.account"
-      save_as: "s_bank_account"
-      values:
-        name: "S Bank Account"
-        code: "SBA"
-        user_type_id: "REC: account_type_liquidity.id"
-        reconcile: false
-
-    - step: "Create the customer invoice type"
-      action: "create"
-      model: "customer_invoice_type"
-      save_as: "s_invoice_type"
-      values:
-        name: "S Invoice Type"
-        code: "/"
-        journal_id: "REC: s_invoice_journal.id"
-        receivable_account_id: "REC: s_receivable_account.id"
-
-    - step: "Create the scholarship type"
-      action: "create"
-      model: "school_scholarship_type"
-      save_as: "s_type"
-      values:
-        name: "S Type"
-        code: "STY"
-        deduction_journal_id: "REC: s_scholarship_journal.id"
-        discount_account_id: "REC: s_discount_account.id"
-
-    - step: "Create the scholarship program"
-      action: "create"
-      model: "school_scholarship_program"
-      save_as: "s_program"
-      values:
-        name: "S Program"
-        code: "SPRG"
-        type_id: "REC: s_type.id"
-        school_id: "REC: s_school.id"
-        academic_year_id: "REC: s_academic_year.id"
-        funding_source_ids: [[6, 0, ["REC: s_funding_source.id"]]]
-        deduction_journal_id: "REC: s_scholarship_journal.id"
-        discount_account_id: "REC: s_discount_account.id"
-        scope_ids:
-          - - 0
-            - 0
-            - scope_basis: "product"
-              product_id: "REC: s_product.id"
-              benefit_type: "cash"
-              computation: "fixed"
-              percentage: 0.0
-              amount_fixed: 100000.0
-
 scenarios:
   # ══════════════════════════════════════════════════════════════════
   # Positive (compute): a plain invoice with no deduction and no
   # payment reports zero on both split fields.
+  #
+  # NOTE ON FIXTURES: this file does NOT use a shared top-level
+  # ``setup:`` block. ``odoo_yaml_test`` replays ``setup:`` before
+  # EVERY scenario against the SAME database transaction (no rollback
+  # in between), so any fixture with a uniqueness constraint --
+  # ``school_grade_type``, ``school``, ``account.journal``,
+  # ``account.account``, etc. all enforce a unique ``code`` -- would
+  # collide on the second replay. Each scenario below therefore builds
+  # its own, uniquely-coded fixtures (``e1_``/``e2_``/``e3_``/``e4_``
+  # prefixes), scoped to exactly what that scenario needs.
   # ══════════════════════════════════════════════════════════════════
   - name: "No Deduction, No Payment - Both Split Fields Stay Zero"
     steps:
+      - step: "Create the student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "e1_contact"
+        values:
+          name: "E1 Contact"
+
+      - step: "Get the account.account.type Income reference"
+        action: "ref"
+        xml_id: "account.data_account_type_revenue"
+        save_as: "e1_account_type_income"
+
+      - step: "Get the account.account.type Receivable reference"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "e1_account_type_receivable"
+
+      - step: "Create the receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "e1_receivable_account"
+        values:
+          name: "E1 Receivable Account"
+          code: "E1RA"
+          user_type_id: "REC: e1_account_type_receivable.id"
+          reconcile: true
+
+      - step: "Create the income account"
+        action: "create"
+        model: "account.account"
+        save_as: "e1_income_account"
+        values:
+          name: "E1 Income Account"
+          code: "E1IA"
+          user_type_id: "REC: e1_account_type_income.id"
+          reconcile: false
+
+      - step: "Create the sales journal used by the invoice's own move"
+        action: "create"
+        model: "account.journal"
+        save_as: "e1_invoice_journal"
+        values:
+          name: "E1 Invoice Journal"
+          code: "E1IJ"
+          type: "sale"
+
+      - step: "Create the customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "e1_invoice_type"
+        values:
+          name: "E1 Invoice Type"
+          code: "/"
+          journal_id: "REC: e1_invoice_journal.id"
+          receivable_account_id: "REC: e1_receivable_account.id"
+
       - step: "Create the plain invoice"
         action: "create"
         model: "customer_invoice"
         save_as: "e1_invoice"
         values:
-          type_id: "REC: s_invoice_type.id"
-          partner_id: "REC: s_contact.id"
+          type_id: "REC: e1_invoice_type.id"
+          partner_id: "REC: e1_contact.id"
           date: 2026-08-01
           date_due: 2026-08-15
           currency_id: "REC: company.currency_id.id"
-          journal_id: "REC: s_invoice_journal.id"
-          receivable_account_id: "REC: s_receivable_account.id"
+          journal_id: "REC: e1_invoice_journal.id"
+          receivable_account_id: "REC: e1_receivable_account.id"
           user_id: "REF: base.user_admin"
 
       - step: "Add a detail line to the plain invoice"
@@ -276,7 +92,7 @@ scenarios:
         values:
           customer_invoice_id: "REC: e1_invoice.id"
           name: "E1 Invoice Line"
-          account_id: "REC: s_income_account.id"
+          account_id: "REC: e1_income_account.id"
           uom_quantity: 1
           price_unit: 1000000.0
 
@@ -331,21 +147,261 @@ scenarios:
   # ══════════════════════════════════════════════════════════════════
   - name: "Partial Deduction, Then Cash Top-Up, Then Cancel Reversal"
     steps:
+      - step: "Create the grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "e2_grade_type"
+        values:
+          name: "E2 Grade Type"
+          code: "E2GT"
+
+      - step: "Create the school"
+        action: "create"
+        model: "school"
+        save_as: "e2_school"
+        values:
+          name: "E2 School"
+          code: "E2SC"
+          grade_type_id: "REC: e2_grade_type.id"
+
+      - step: "Create the academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "e2_academic_year"
+        values:
+          name: "E2 Academic Year"
+          code: "E2AY"
+          date_start: 2026-07-01
+          date_end: 2027-06-30
+
+      - step: "Create the academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "e2_academic_term"
+        values:
+          name: "E2 Term"
+          code: "E2TM"
+          date_start: 2026-07-01
+          date_end: 2026-12-31
+          year_id: "REC: e2_academic_year.id"
+
+      - step: "Create the grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "e2_grade"
+        values:
+          name: "E2 Grade"
+          code: "E2GR"
+          type_id: "REC: e2_grade_type.id"
+
+      - step: "Create the grade class"
+        action: "create"
+        model: "school_grade_class"
+        save_as: "e2_grade_class"
+        values:
+          name: "E2 Class"
+          code: "E2CL"
+          school_id: "REC: e2_school.id"
+          grade_id: "REC: e2_grade.id"
+
+      - step: "Create the student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "e2_contact"
+        values:
+          name: "E2 Contact"
+
+      - step: "Create the student"
+        action: "create"
+        model: "school_student"
+        save_as: "e2_student"
+        values:
+          name: "E2 Student"
+          code: "E2ST"
+          contact_id: "REC: e2_contact.id"
+          school_id: "REC: e2_school.id"
+
+      - step: "Create the enrollment"
+        action: "create"
+        model: "school_enrollment"
+        save_as: "e2_enrollment"
+        values:
+          academic_year_id: "REC: e2_academic_year.id"
+          academic_term_id: "REC: e2_academic_term.id"
+          school_id: "REC: e2_school.id"
+          grade_id: "REC: e2_grade.id"
+          grade_class_id: "REC: e2_grade_class.id"
+          student_id: "REC: e2_student.id"
+
+      - step: "Create the analytic account for the funding source"
+        action: "create"
+        model: "account.analytic.account"
+        save_as: "e2_analytic"
+        values:
+          name: "E2 Analytic"
+
+      - step: "Create the funding source"
+        action: "create"
+        model: "school_scholarship_funding_source"
+        save_as: "e2_funding_source"
+        values:
+          name: "E2 Funding Source"
+          code: "E2FS"
+          analytic_account_id: "REC: e2_analytic.id"
+
+      - step: "Create the product covered by the benefit lines"
+        action: "create"
+        model: "product.product"
+        save_as: "e2_product"
+        values:
+          name: "E2 Product"
+          type: "service"
+
+      # ── Two DIFFERENT journals, so the compute's own journal-based
+      # split is genuinely exercised: the scholarship journal only
+      # ever posts deduction documents, and the bank journal only
+      # ever posts the plain cash top-up that must NEVER be mistaken
+      # for a scholarship. ──────────────────────────────────────────
+      - step: "Create the sales journal used by the invoice's own move"
+        action: "create"
+        model: "account.journal"
+        save_as: "e2_invoice_journal"
+        values:
+          name: "E2 Invoice Journal"
+          code: "E2IJ"
+          type: "sale"
+
+      - step: "Create the journal used by scholarship deduction documents"
+        action: "create"
+        model: "account.journal"
+        save_as: "e2_scholarship_journal"
+        values:
+          name: "E2 Scholarship Journal"
+          code: "E2SJ"
+          type: "general"
+
+      - step: "Create the bank journal used by the plain cash top-up"
+        action: "create"
+        model: "account.journal"
+        save_as: "e2_bank_journal"
+        values:
+          name: "E2 Bank Journal"
+          code: "E2BJ"
+          type: "bank"
+
+      - step: "Get the account.account.type Income reference"
+        action: "ref"
+        xml_id: "account.data_account_type_revenue"
+        save_as: "e2_account_type_income"
+
+      - step: "Get the account.account.type Receivable reference"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "e2_account_type_receivable"
+
+      - step: "Get the account.account.type Liquidity reference"
+        action: "ref"
+        xml_id: "account.data_account_type_liquidity"
+        save_as: "e2_account_type_liquidity"
+
+      - step: "Create the receivable account shared by the invoice and the deduction"
+        action: "create"
+        model: "account.account"
+        save_as: "e2_receivable_account"
+        values:
+          name: "E2 Receivable Account"
+          code: "E2RA"
+          user_type_id: "REC: e2_account_type_receivable.id"
+          reconcile: true
+
+      - step: "Create the discount account the deduction line posts to"
+        action: "create"
+        model: "account.account"
+        save_as: "e2_discount_account"
+        values:
+          name: "E2 Discount Account"
+          code: "E2DA"
+          user_type_id: "REC: e2_account_type_income.id"
+          reconcile: false
+
+      - step: "Create the income account the invoice line posts to"
+        action: "create"
+        model: "account.account"
+        save_as: "e2_income_account"
+        values:
+          name: "E2 Income Account"
+          code: "E2IA"
+          user_type_id: "REC: e2_account_type_income.id"
+          reconcile: false
+
+      - step: "Create the bank account the cash top-up debits"
+        action: "create"
+        model: "account.account"
+        save_as: "e2_bank_account"
+        values:
+          name: "E2 Bank Account"
+          code: "E2BA"
+          user_type_id: "REC: e2_account_type_liquidity.id"
+          reconcile: false
+
+      - step: "Create the customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "e2_invoice_type"
+        values:
+          name: "E2 Invoice Type"
+          code: "/"
+          journal_id: "REC: e2_invoice_journal.id"
+          receivable_account_id: "REC: e2_receivable_account.id"
+
+      - step: "Create the scholarship type"
+        action: "create"
+        model: "school_scholarship_type"
+        save_as: "e2_type"
+        values:
+          name: "E2 Type"
+          code: "E2TY"
+          deduction_journal_id: "REC: e2_scholarship_journal.id"
+          discount_account_id: "REC: e2_discount_account.id"
+
+      - step: "Create the scholarship program"
+        action: "create"
+        model: "school_scholarship_program"
+        save_as: "e2_program"
+        values:
+          name: "E2 Program"
+          code: "E2PR"
+          type_id: "REC: e2_type.id"
+          school_id: "REC: e2_school.id"
+          academic_year_id: "REC: e2_academic_year.id"
+          funding_source_ids: [[6, 0, ["REC: e2_funding_source.id"]]]
+          deduction_journal_id: "REC: e2_scholarship_journal.id"
+          discount_account_id: "REC: e2_discount_account.id"
+          scope_ids:
+            - - 0
+              - 0
+              - scope_basis: "product"
+                product_id: "REC: e2_product.id"
+                benefit_type: "cash"
+                computation: "fixed"
+                percentage: 0.0
+                amount_fixed: 100000.0
+
       - step: "Create the award backing the partial deduction"
         action: "create"
         model: "school_scholarship_award"
         save_as: "e2_award"
         values:
-          program_id: "REC: s_program.id"
-          student_id: "REC: s_student.id"
-          enrollment_id: "REC: s_enrollment.id"
+          program_id: "REC: e2_program.id"
+          student_id: "REC: e2_student.id"
+          enrollment_id: "REC: e2_enrollment.id"
           date_start: 2026-07-01
           date_end: 2026-12-31
           benefit_ids:
             - - 0
               - 0
               - name: "E2 Benefit"
-                product_id: "REC: s_product.id"
+                product_id: "REC: e2_product.id"
                 benefit_type: "cash"
                 computation: "fixed"
                 amount_fixed: 400000.0
@@ -353,7 +409,7 @@ scenarios:
           funding_ids:
             - - 0
               - 0
-              - funding_source_id: "REC: s_funding_source.id"
+              - funding_source_id: "REC: e2_funding_source.id"
                 percentage: 100.0
 
       - step: "Find the award's Benefit line"
@@ -384,13 +440,13 @@ scenarios:
         model: "customer_invoice"
         save_as: "e2_invoice"
         values:
-          type_id: "REC: s_invoice_type.id"
-          partner_id: "REC: s_contact.id"
+          type_id: "REC: e2_invoice_type.id"
+          partner_id: "REC: e2_contact.id"
           date: 2026-08-01
           date_due: 2026-08-15
           currency_id: "REC: company.currency_id.id"
-          journal_id: "REC: s_invoice_journal.id"
-          receivable_account_id: "REC: s_receivable_account.id"
+          journal_id: "REC: e2_invoice_journal.id"
+          receivable_account_id: "REC: e2_receivable_account.id"
           user_id: "REF: base.user_admin"
 
       - step: "Add a detail line to the invoice"
@@ -400,7 +456,7 @@ scenarios:
         values:
           customer_invoice_id: "REC: e2_invoice.id"
           name: "E2 Invoice Line"
-          account_id: "REC: s_income_account.id"
+          account_id: "REC: e2_income_account.id"
           uom_quantity: 1
           price_unit: 1000000.0
 
@@ -436,15 +492,15 @@ scenarios:
         values:
           award_id: "REC: e2_award.id"
           date: 2026-08-05
-          journal_id: "REC: s_scholarship_journal.id"
-          receivable_account_id: "REC: s_receivable_account.id"
+          journal_id: "REC: e2_scholarship_journal.id"
+          receivable_account_id: "REC: e2_receivable_account.id"
           user_id: "REF: base.user_admin"
           line_ids:
             - - 0
               - 0
               - schedule_id: "REC: e2_schedule.id"
                 funding_id: "REC: e2_funding.id"
-                final_account_id: "REC: s_discount_account.id"
+                final_account_id: "REC: e2_discount_account.id"
                 name: "E2 Deduction Line"
                 uom_quantity: 1
                 price_unit: 400000.0
@@ -509,21 +565,21 @@ scenarios:
         model: "account.move"
         save_as: "e2_bank_move"
         values:
-          journal_id: "REC: s_bank_journal.id"
+          journal_id: "REC: e2_bank_journal.id"
           date: 2026-08-10
           line_ids:
             - - 0
               - 0
-              - account_id: "REC: s_bank_account.id"
+              - account_id: "REC: e2_bank_account.id"
                 name: "E2 Cash Deposit - Bank"
-                partner_id: "REC: s_contact.id"
+                partner_id: "REC: e2_contact.id"
                 debit: 600000.0
                 credit: 0.0
             - - 0
               - 0
-              - account_id: "REC: s_receivable_account.id"
+              - account_id: "REC: e2_receivable_account.id"
                 name: "E2 Cash Deposit - Receivable"
-                partner_id: "REC: s_contact.id"
+                partner_id: "REC: e2_contact.id"
                 debit: 0.0
                 credit: 600000.0
 
@@ -622,21 +678,232 @@ scenarios:
   # ══════════════════════════════════════════════════════════════════
   - name: "Invoice Fully Covered By Scholarship Stays Zero Cash, Even When Paid"
     steps:
+      - step: "Create the grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "e3_grade_type"
+        values:
+          name: "E3 Grade Type"
+          code: "E3GT"
+
+      - step: "Create the school"
+        action: "create"
+        model: "school"
+        save_as: "e3_school"
+        values:
+          name: "E3 School"
+          code: "E3SC"
+          grade_type_id: "REC: e3_grade_type.id"
+
+      - step: "Create the academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "e3_academic_year"
+        values:
+          name: "E3 Academic Year"
+          code: "E3AY"
+          date_start: 2026-07-01
+          date_end: 2027-06-30
+
+      - step: "Create the academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "e3_academic_term"
+        values:
+          name: "E3 Term"
+          code: "E3TM"
+          date_start: 2026-07-01
+          date_end: 2026-12-31
+          year_id: "REC: e3_academic_year.id"
+
+      - step: "Create the grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "e3_grade"
+        values:
+          name: "E3 Grade"
+          code: "E3GR"
+          type_id: "REC: e3_grade_type.id"
+
+      - step: "Create the grade class"
+        action: "create"
+        model: "school_grade_class"
+        save_as: "e3_grade_class"
+        values:
+          name: "E3 Class"
+          code: "E3CL"
+          school_id: "REC: e3_school.id"
+          grade_id: "REC: e3_grade.id"
+
+      - step: "Create the student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "e3_contact"
+        values:
+          name: "E3 Contact"
+
+      - step: "Create the student"
+        action: "create"
+        model: "school_student"
+        save_as: "e3_student"
+        values:
+          name: "E3 Student"
+          code: "E3ST"
+          contact_id: "REC: e3_contact.id"
+          school_id: "REC: e3_school.id"
+
+      - step: "Create the enrollment"
+        action: "create"
+        model: "school_enrollment"
+        save_as: "e3_enrollment"
+        values:
+          academic_year_id: "REC: e3_academic_year.id"
+          academic_term_id: "REC: e3_academic_term.id"
+          school_id: "REC: e3_school.id"
+          grade_id: "REC: e3_grade.id"
+          grade_class_id: "REC: e3_grade_class.id"
+          student_id: "REC: e3_student.id"
+
+      - step: "Create the analytic account for the funding source"
+        action: "create"
+        model: "account.analytic.account"
+        save_as: "e3_analytic"
+        values:
+          name: "E3 Analytic"
+
+      - step: "Create the funding source"
+        action: "create"
+        model: "school_scholarship_funding_source"
+        save_as: "e3_funding_source"
+        values:
+          name: "E3 Funding Source"
+          code: "E3FS"
+          analytic_account_id: "REC: e3_analytic.id"
+
+      - step: "Create the product covered by the benefit lines"
+        action: "create"
+        model: "product.product"
+        save_as: "e3_product"
+        values:
+          name: "E3 Product"
+          type: "service"
+
+      - step: "Create the sales journal used by the invoice's own move"
+        action: "create"
+        model: "account.journal"
+        save_as: "e3_invoice_journal"
+        values:
+          name: "E3 Invoice Journal"
+          code: "E3IJ"
+          type: "sale"
+
+      - step: "Create the journal used by scholarship deduction documents"
+        action: "create"
+        model: "account.journal"
+        save_as: "e3_scholarship_journal"
+        values:
+          name: "E3 Scholarship Journal"
+          code: "E3SJ"
+          type: "general"
+
+      - step: "Get the account.account.type Income reference"
+        action: "ref"
+        xml_id: "account.data_account_type_revenue"
+        save_as: "e3_account_type_income"
+
+      - step: "Get the account.account.type Receivable reference"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "e3_account_type_receivable"
+
+      - step: "Create the receivable account shared by the invoice and the deduction"
+        action: "create"
+        model: "account.account"
+        save_as: "e3_receivable_account"
+        values:
+          name: "E3 Receivable Account"
+          code: "E3RA"
+          user_type_id: "REC: e3_account_type_receivable.id"
+          reconcile: true
+
+      - step: "Create the discount account the deduction line posts to"
+        action: "create"
+        model: "account.account"
+        save_as: "e3_discount_account"
+        values:
+          name: "E3 Discount Account"
+          code: "E3DA"
+          user_type_id: "REC: e3_account_type_income.id"
+          reconcile: false
+
+      - step: "Create the income account the invoice line posts to"
+        action: "create"
+        model: "account.account"
+        save_as: "e3_income_account"
+        values:
+          name: "E3 Income Account"
+          code: "E3IA"
+          user_type_id: "REC: e3_account_type_income.id"
+          reconcile: false
+
+      - step: "Create the customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "e3_invoice_type"
+        values:
+          name: "E3 Invoice Type"
+          code: "/"
+          journal_id: "REC: e3_invoice_journal.id"
+          receivable_account_id: "REC: e3_receivable_account.id"
+
+      - step: "Create the scholarship type"
+        action: "create"
+        model: "school_scholarship_type"
+        save_as: "e3_type"
+        values:
+          name: "E3 Type"
+          code: "E3TY"
+          deduction_journal_id: "REC: e3_scholarship_journal.id"
+          discount_account_id: "REC: e3_discount_account.id"
+
+      - step: "Create the scholarship program"
+        action: "create"
+        model: "school_scholarship_program"
+        save_as: "e3_program"
+        values:
+          name: "E3 Program"
+          code: "E3PR"
+          type_id: "REC: e3_type.id"
+          school_id: "REC: e3_school.id"
+          academic_year_id: "REC: e3_academic_year.id"
+          funding_source_ids: [[6, 0, ["REC: e3_funding_source.id"]]]
+          deduction_journal_id: "REC: e3_scholarship_journal.id"
+          discount_account_id: "REC: e3_discount_account.id"
+          scope_ids:
+            - - 0
+              - 0
+              - scope_basis: "product"
+                product_id: "REC: e3_product.id"
+                benefit_type: "cash"
+                computation: "fixed"
+                percentage: 0.0
+                amount_fixed: 100000.0
+
       - step: "Create the award backing the full deduction"
         action: "create"
         model: "school_scholarship_award"
         save_as: "e3_award"
         values:
-          program_id: "REC: s_program.id"
-          student_id: "REC: s_student.id"
-          enrollment_id: "REC: s_enrollment.id"
+          program_id: "REC: e3_program.id"
+          student_id: "REC: e3_student.id"
+          enrollment_id: "REC: e3_enrollment.id"
           date_start: 2026-07-01
           date_end: 2026-12-31
           benefit_ids:
             - - 0
               - 0
               - name: "E3 Benefit"
-                product_id: "REC: s_product.id"
+                product_id: "REC: e3_product.id"
                 benefit_type: "cash"
                 computation: "fixed"
                 amount_fixed: 1000000.0
@@ -644,7 +911,7 @@ scenarios:
           funding_ids:
             - - 0
               - 0
-              - funding_source_id: "REC: s_funding_source.id"
+              - funding_source_id: "REC: e3_funding_source.id"
                 percentage: 100.0
 
       - step: "Find the award's Benefit line"
@@ -675,13 +942,13 @@ scenarios:
         model: "customer_invoice"
         save_as: "e3_invoice"
         values:
-          type_id: "REC: s_invoice_type.id"
-          partner_id: "REC: s_contact.id"
+          type_id: "REC: e3_invoice_type.id"
+          partner_id: "REC: e3_contact.id"
           date: 2026-08-01
           date_due: 2026-08-15
           currency_id: "REC: company.currency_id.id"
-          journal_id: "REC: s_invoice_journal.id"
-          receivable_account_id: "REC: s_receivable_account.id"
+          journal_id: "REC: e3_invoice_journal.id"
+          receivable_account_id: "REC: e3_receivable_account.id"
           user_id: "REF: base.user_admin"
 
       - step: "Add a detail line to the invoice"
@@ -691,7 +958,7 @@ scenarios:
         values:
           customer_invoice_id: "REC: e3_invoice.id"
           name: "E3 Invoice Line"
-          account_id: "REC: s_income_account.id"
+          account_id: "REC: e3_income_account.id"
           uom_quantity: 1
           price_unit: 1000000.0
 
@@ -724,15 +991,15 @@ scenarios:
         values:
           award_id: "REC: e3_award.id"
           date: 2026-08-05
-          journal_id: "REC: s_scholarship_journal.id"
-          receivable_account_id: "REC: s_receivable_account.id"
+          journal_id: "REC: e3_scholarship_journal.id"
+          receivable_account_id: "REC: e3_receivable_account.id"
           user_id: "REF: base.user_admin"
           line_ids:
             - - 0
               - 0
               - schedule_id: "REC: e3_schedule.id"
                 funding_id: "REC: e3_funding.id"
-                final_account_id: "REC: s_discount_account.id"
+                final_account_id: "REC: e3_discount_account.id"
                 name: "E3 Deduction Line"
                 uom_quantity: 1
                 price_unit: 1000000.0
@@ -796,6 +1063,93 @@ scenarios:
   # ══════════════════════════════════════════════════════════════════
   - name: "Bank-Only Settlement Never Counts As Scholarship"
     steps:
+      - step: "Create the student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "e4_contact"
+        values:
+          name: "E4 Contact"
+
+      - step: "Create a sponsor contact, unrelated to the student"
+        action: "create"
+        model: "res.partner"
+        save_as: "e4_sponsor_contact"
+        values:
+          name: "E4 Sponsor Contact"
+
+      - step: "Get the account.account.type Income reference"
+        action: "ref"
+        xml_id: "account.data_account_type_revenue"
+        save_as: "e4_account_type_income"
+
+      - step: "Get the account.account.type Receivable reference"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "e4_account_type_receivable"
+
+      - step: "Get the account.account.type Liquidity reference"
+        action: "ref"
+        xml_id: "account.data_account_type_liquidity"
+        save_as: "e4_account_type_liquidity"
+
+      - step: "Create the receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "e4_receivable_account"
+        values:
+          name: "E4 Receivable Account"
+          code: "E4RA"
+          user_type_id: "REC: e4_account_type_receivable.id"
+          reconcile: true
+
+      - step: "Create the income account"
+        action: "create"
+        model: "account.account"
+        save_as: "e4_income_account"
+        values:
+          name: "E4 Income Account"
+          code: "E4IA"
+          user_type_id: "REC: e4_account_type_income.id"
+          reconcile: false
+
+      - step: "Create the bank account the cash deposits debit"
+        action: "create"
+        model: "account.account"
+        save_as: "e4_bank_account"
+        values:
+          name: "E4 Bank Account"
+          code: "E4BA"
+          user_type_id: "REC: e4_account_type_liquidity.id"
+          reconcile: false
+
+      - step: "Create the sales journal used by the invoice's own move"
+        action: "create"
+        model: "account.journal"
+        save_as: "e4_invoice_journal"
+        values:
+          name: "E4 Invoice Journal"
+          code: "E4IJ"
+          type: "sale"
+
+      - step: "Create the bank journal used by plain cash deposits"
+        action: "create"
+        model: "account.journal"
+        save_as: "e4_bank_journal"
+        values:
+          name: "E4 Bank Journal"
+          code: "E4BJ"
+          type: "bank"
+
+      - step: "Create the customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "e4_invoice_type"
+        values:
+          name: "E4 Invoice Type"
+          code: "/"
+          journal_id: "REC: e4_invoice_journal.id"
+          receivable_account_id: "REC: e4_receivable_account.id"
+
       # ── Negative: settled entirely by the student's own bank
       # deposit, no deduction at all ──────────────────────────────────
       - step: "Create the invoice settled purely by a bank deposit"
@@ -803,13 +1157,13 @@ scenarios:
         model: "customer_invoice"
         save_as: "e4_invoice_own"
         values:
-          type_id: "REC: s_invoice_type.id"
-          partner_id: "REC: s_contact.id"
+          type_id: "REC: e4_invoice_type.id"
+          partner_id: "REC: e4_contact.id"
           date: 2026-08-01
           date_due: 2026-08-15
           currency_id: "REC: company.currency_id.id"
-          journal_id: "REC: s_invoice_journal.id"
-          receivable_account_id: "REC: s_receivable_account.id"
+          journal_id: "REC: e4_invoice_journal.id"
+          receivable_account_id: "REC: e4_receivable_account.id"
           user_id: "REF: base.user_admin"
 
       - step: "Add a detail line to the bank-only invoice"
@@ -819,7 +1173,7 @@ scenarios:
         values:
           customer_invoice_id: "REC: e4_invoice_own.id"
           name: "E4 Own Invoice Line"
-          account_id: "REC: s_income_account.id"
+          account_id: "REC: e4_income_account.id"
           uom_quantity: 1
           price_unit: 1000000.0
 
@@ -850,21 +1204,21 @@ scenarios:
         model: "account.move"
         save_as: "e4_own_bank_move"
         values:
-          journal_id: "REC: s_bank_journal.id"
+          journal_id: "REC: e4_bank_journal.id"
           date: 2026-08-10
           line_ids:
             - - 0
               - 0
-              - account_id: "REC: s_bank_account.id"
+              - account_id: "REC: e4_bank_account.id"
                 name: "E4 Own Cash Deposit - Bank"
-                partner_id: "REC: s_contact.id"
+                partner_id: "REC: e4_contact.id"
                 debit: 1000000.0
                 credit: 0.0
             - - 0
               - 0
-              - account_id: "REC: s_receivable_account.id"
+              - account_id: "REC: e4_receivable_account.id"
                 name: "E4 Own Cash Deposit - Receivable"
-                partner_id: "REC: s_contact.id"
+                partner_id: "REC: e4_contact.id"
                 debit: 0.0
                 credit: 1000000.0
 
@@ -929,13 +1283,13 @@ scenarios:
         model: "customer_invoice"
         save_as: "e4_invoice_sponsor"
         values:
-          type_id: "REC: s_invoice_type.id"
-          partner_id: "REC: s_contact.id"
+          type_id: "REC: e4_invoice_type.id"
+          partner_id: "REC: e4_contact.id"
           date: 2026-08-01
           date_due: 2026-08-15
           currency_id: "REC: company.currency_id.id"
-          journal_id: "REC: s_invoice_journal.id"
-          receivable_account_id: "REC: s_receivable_account.id"
+          journal_id: "REC: e4_invoice_journal.id"
+          receivable_account_id: "REC: e4_receivable_account.id"
           user_id: "REF: base.user_admin"
 
       - step: "Add a detail line to the sponsor-paid invoice"
@@ -945,7 +1299,7 @@ scenarios:
         values:
           customer_invoice_id: "REC: e4_invoice_sponsor.id"
           name: "E4 Sponsor Invoice Line"
-          account_id: "REC: s_income_account.id"
+          account_id: "REC: e4_income_account.id"
           uom_quantity: 1
           price_unit: 1000000.0
 
@@ -976,21 +1330,21 @@ scenarios:
         model: "account.move"
         save_as: "e4_sponsor_bank_move"
         values:
-          journal_id: "REC: s_bank_journal.id"
+          journal_id: "REC: e4_bank_journal.id"
           date: 2026-08-10
           line_ids:
             - - 0
               - 0
-              - account_id: "REC: s_bank_account.id"
+              - account_id: "REC: e4_bank_account.id"
                 name: "E4 Sponsor Cash Deposit - Bank"
-                partner_id: "REC: s_sponsor_contact.id"
+                partner_id: "REC: e4_sponsor_contact.id"
                 debit: 1000000.0
                 credit: 0.0
             - - 0
               - 0
-              - account_id: "REC: s_receivable_account.id"
+              - account_id: "REC: e4_receivable_account.id"
                 name: "E4 Sponsor Cash Deposit - Receivable"
-                partner_id: "REC: s_sponsor_contact.id"
+                partner_id: "REC: e4_sponsor_contact.id"
                 debit: 0.0
                 credit: 1000000.0
 

--- a/ssi_school_scholarship_deduction/tests/test_data_customer_invoice_scholarship_deduction.yaml
+++ b/ssi_school_scholarship_deduction/tests/test_data_customer_invoice_scholarship_deduction.yaml
@@ -1,0 +1,1052 @@
+setup:
+  steps:
+    - step: "Create the grade type"
+      action: "create"
+      model: "school_grade_type"
+      save_as: "s_grade_type"
+      values:
+        name: "S Grade Type"
+        code: "SGT"
+
+    - step: "Create the school"
+      action: "create"
+      model: "school"
+      save_as: "s_school"
+      values:
+        name: "S School"
+        code: "SSC"
+        grade_type_id: "REC: s_grade_type.id"
+
+    - step: "Create the academic year"
+      action: "create"
+      model: "school_academic_year"
+      save_as: "s_academic_year"
+      values:
+        name: "S Academic Year"
+        code: "SAY"
+        date_start: 2026-07-01
+        date_end: 2027-06-30
+
+    - step: "Create the academic term"
+      action: "create"
+      model: "school_academic_term"
+      save_as: "s_academic_term"
+      values:
+        name: "S Term"
+        code: "STM"
+        date_start: 2026-07-01
+        date_end: 2026-12-31
+        year_id: "REC: s_academic_year.id"
+
+    - step: "Create the grade"
+      action: "create"
+      model: "school_grade"
+      save_as: "s_grade"
+      values:
+        name: "S Grade"
+        code: "SGR"
+        type_id: "REC: s_grade_type.id"
+
+    - step: "Create the grade class"
+      action: "create"
+      model: "school_grade_class"
+      save_as: "s_grade_class"
+      values:
+        name: "S Class"
+        code: "SCL"
+        school_id: "REC: s_school.id"
+        grade_id: "REC: s_grade.id"
+
+    - step: "Create the student contact"
+      action: "create"
+      model: "res.partner"
+      save_as: "s_contact"
+      values:
+        name: "S Contact"
+
+    - step: "Create a sponsor contact, unrelated to the student"
+      action: "create"
+      model: "res.partner"
+      save_as: "s_sponsor_contact"
+      values:
+        name: "S Sponsor Contact"
+
+    - step: "Create the student"
+      action: "create"
+      model: "school_student"
+      save_as: "s_student"
+      values:
+        name: "S Student"
+        code: "SST"
+        contact_id: "REC: s_contact.id"
+        school_id: "REC: s_school.id"
+
+    - step: "Create the enrollment"
+      action: "create"
+      model: "school_enrollment"
+      save_as: "s_enrollment"
+      values:
+        academic_year_id: "REC: s_academic_year.id"
+        academic_term_id: "REC: s_academic_term.id"
+        school_id: "REC: s_school.id"
+        grade_id: "REC: s_grade.id"
+        grade_class_id: "REC: s_grade_class.id"
+        student_id: "REC: s_student.id"
+
+    - step: "Create the analytic account for the funding source"
+      action: "create"
+      model: "account.analytic.account"
+      save_as: "s_analytic"
+      values:
+        name: "S Analytic"
+
+    - step: "Create the funding source"
+      action: "create"
+      model: "school_scholarship_funding_source"
+      save_as: "s_funding_source"
+      values:
+        name: "S Funding Source"
+        code: "SFS"
+        analytic_account_id: "REC: s_analytic.id"
+
+    - step: "Create the product covered by the benefit lines"
+      action: "create"
+      model: "product.product"
+      save_as: "s_product"
+      values:
+        name: "S Product"
+        type: "service"
+
+    # ── Three DIFFERENT journals, so the compute's own journal-based
+    # split is genuinely exercised: the sales journal only ever posts
+    # the invoice's own move, the scholarship journal only ever posts
+    # deduction documents, and the bank journal only ever posts plain
+    # cash-deposit journal entries that must NEVER be mistaken for a
+    # scholarship. ──────────────────────────────────────────────────
+    - step: "Create the sales journal used by the invoice's own move"
+      action: "create"
+      model: "account.journal"
+      save_as: "s_invoice_journal"
+      values:
+        name: "S Invoice Journal"
+        code: "SIJ"
+        type: "sale"
+
+    - step: "Create the journal used by scholarship deduction documents"
+      action: "create"
+      model: "account.journal"
+      save_as: "s_scholarship_journal"
+      values:
+        name: "S Scholarship Journal"
+        code: "SSJ"
+        type: "general"
+
+    - step: "Create the bank journal used by plain cash deposits"
+      action: "create"
+      model: "account.journal"
+      save_as: "s_bank_journal"
+      values:
+        name: "S Bank Journal"
+        code: "SBJ"
+        type: "bank"
+
+    - step: "Get the account.account.type Income reference"
+      action: "ref"
+      xml_id: "account.data_account_type_revenue"
+      save_as: "account_type_income"
+
+    - step: "Get the account.account.type Receivable reference"
+      action: "ref"
+      xml_id: "account.data_account_type_receivable"
+      save_as: "account_type_receivable"
+
+    - step: "Get the account.account.type Liquidity reference"
+      action: "ref"
+      xml_id: "account.data_account_type_liquidity"
+      save_as: "account_type_liquidity"
+
+    - step: "Create the receivable account shared by invoices and deductions"
+      action: "create"
+      model: "account.account"
+      save_as: "s_receivable_account"
+      values:
+        name: "S Receivable Account"
+        code: "SRA"
+        user_type_id: "REC: account_type_receivable.id"
+        reconcile: true
+
+    - step: "Create the discount account the deduction lines post to"
+      action: "create"
+      model: "account.account"
+      save_as: "s_discount_account"
+      values:
+        name: "S Discount Account"
+        code: "SDA"
+        user_type_id: "REC: account_type_income.id"
+        reconcile: false
+
+    - step: "Create the income account the invoice lines post to"
+      action: "create"
+      model: "account.account"
+      save_as: "s_income_account"
+      values:
+        name: "S Income Account"
+        code: "SIA"
+        user_type_id: "REC: account_type_income.id"
+        reconcile: false
+
+    - step: "Create the bank account the cash deposits debit"
+      action: "create"
+      model: "account.account"
+      save_as: "s_bank_account"
+      values:
+        name: "S Bank Account"
+        code: "SBA"
+        user_type_id: "REC: account_type_liquidity.id"
+        reconcile: false
+
+    - step: "Create the customer invoice type"
+      action: "create"
+      model: "customer_invoice_type"
+      save_as: "s_invoice_type"
+      values:
+        name: "S Invoice Type"
+        code: "/"
+        journal_id: "REC: s_invoice_journal.id"
+        receivable_account_id: "REC: s_receivable_account.id"
+
+    - step: "Create the scholarship type"
+      action: "create"
+      model: "school_scholarship_type"
+      save_as: "s_type"
+      values:
+        name: "S Type"
+        code: "STY"
+        deduction_journal_id: "REC: s_scholarship_journal.id"
+        discount_account_id: "REC: s_discount_account.id"
+
+    - step: "Create the scholarship program"
+      action: "create"
+      model: "school_scholarship_program"
+      save_as: "s_program"
+      values:
+        name: "S Program"
+        code: "SPRG"
+        type_id: "REC: s_type.id"
+        school_id: "REC: s_school.id"
+        academic_year_id: "REC: s_academic_year.id"
+        funding_source_ids: [[6, 0, ["REC: s_funding_source.id"]]]
+        deduction_journal_id: "REC: s_scholarship_journal.id"
+        discount_account_id: "REC: s_discount_account.id"
+        scope_ids:
+          - - 0
+            - 0
+            - scope_basis: "product"
+              product_id: "REC: s_product.id"
+              benefit_type: "cash"
+              computation: "fixed"
+              percentage: 0.0
+              amount_fixed: 100000.0
+
+scenarios:
+  # ══════════════════════════════════════════════════════════════════
+  # Positive (compute): a plain invoice with no deduction and no
+  # payment reports zero on both split fields.
+  # ══════════════════════════════════════════════════════════════════
+  - name: "No Deduction, No Payment - Both Split Fields Stay Zero"
+    steps:
+      - step: "Create the plain invoice"
+        action: "create"
+        model: "customer_invoice"
+        save_as: "e1_invoice"
+        values:
+          type_id: "REC: s_invoice_type.id"
+          partner_id: "REC: s_contact.id"
+          date: 2026-08-01
+          date_due: 2026-08-15
+          currency_id: "REC: company.currency_id.id"
+          journal_id: "REC: s_invoice_journal.id"
+          receivable_account_id: "REC: s_receivable_account.id"
+          user_id: "REF: base.user_admin"
+
+      - step: "Add a detail line to the plain invoice"
+        action: "create"
+        model: "customer_invoice.line"
+        save_as: "e1_invoice_line"
+        values:
+          customer_invoice_id: "REC: e1_invoice.id"
+          name: "E1 Invoice Line"
+          account_id: "REC: s_income_account.id"
+          uom_quantity: 1
+          price_unit: 1000000.0
+
+      - step: "Confirm the plain invoice"
+        action: "call"
+        target: "e1_invoice"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+        refresh: true
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
+
+      - step: "Approve the plain invoice, posting its journal entry"
+        action: "call"
+        target: "e1_invoice"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        refresh: true
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+          amount_residual:
+            type: "value"
+            expected: 1000000.0
+
+      - step: "Assert both split fields, and the flag, stay zero/false"
+        action: "assert"
+        target: "e1_invoice"
+        asserts:
+          amount_settled_by_scholarship:
+            type: "value"
+            expected: 0.0
+          amount_settled_by_cash:
+            type: "value"
+            expected: 0.0
+          has_scholarship:
+            type: "value"
+            expected: false
+          scholarship_deduction_ids:
+            type: "m2m"
+            check: "count"
+            expected_count: 0
+
+  # ══════════════════════════════════════════════════════════════════
+  # Positive (compute): a 400000 deduction against a 1000000 invoice,
+  # then a 600000 cash top-up, then cancelling the deduction. Covers
+  # the M2M trace (scholarship_deduction_ids) and the reversal on
+  # cancel.
+  # ══════════════════════════════════════════════════════════════════
+  - name: "Partial Deduction, Then Cash Top-Up, Then Cancel Reversal"
+    steps:
+      - step: "Create the award backing the partial deduction"
+        action: "create"
+        model: "school_scholarship_award"
+        save_as: "e2_award"
+        values:
+          program_id: "REC: s_program.id"
+          student_id: "REC: s_student.id"
+          enrollment_id: "REC: s_enrollment.id"
+          date_start: 2026-07-01
+          date_end: 2026-12-31
+          benefit_ids:
+            - - 0
+              - 0
+              - name: "E2 Benefit"
+                product_id: "REC: s_product.id"
+                benefit_type: "cash"
+                computation: "fixed"
+                amount_fixed: 400000.0
+                periodicity: "one_time"
+          funding_ids:
+            - - 0
+              - 0
+              - funding_source_id: "REC: s_funding_source.id"
+                percentage: 100.0
+
+      - step: "Find the award's Benefit line"
+        action: "search"
+        model: "school_scholarship_award_benefit"
+        domain: [["award_id", "=", "REC: e2_award.id"]]
+        limit: 1
+        save_as: "e2_benefit"
+
+      - step: "Find the award's Funding line"
+        action: "search"
+        model: "school_scholarship_award_funding"
+        domain: [["award_id", "=", "REC: e2_award.id"]]
+        limit: 1
+        save_as: "e2_funding"
+
+      - step: "Create the Schedule line realizing the Benefit"
+        action: "create"
+        model: "school_scholarship_award_schedule"
+        save_as: "e2_schedule"
+        values:
+          benefit_id: "REC: e2_benefit.id"
+          date: 2026-08-01
+          state: "scheduled"
+
+      - step: "Create the invoice the partial deduction is allocated against"
+        action: "create"
+        model: "customer_invoice"
+        save_as: "e2_invoice"
+        values:
+          type_id: "REC: s_invoice_type.id"
+          partner_id: "REC: s_contact.id"
+          date: 2026-08-01
+          date_due: 2026-08-15
+          currency_id: "REC: company.currency_id.id"
+          journal_id: "REC: s_invoice_journal.id"
+          receivable_account_id: "REC: s_receivable_account.id"
+          user_id: "REF: base.user_admin"
+
+      - step: "Add a detail line to the invoice"
+        action: "create"
+        model: "customer_invoice.line"
+        save_as: "e2_invoice_line"
+        values:
+          customer_invoice_id: "REC: e2_invoice.id"
+          name: "E2 Invoice Line"
+          account_id: "REC: s_income_account.id"
+          uom_quantity: 1
+          price_unit: 1000000.0
+
+      - step: "Confirm the invoice"
+        action: "call"
+        target: "e2_invoice"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+        refresh: true
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
+
+      - step: "Approve the invoice, posting its journal entry"
+        action: "call"
+        target: "e2_invoice"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        refresh: true
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+          amount_residual:
+            type: "value"
+            expected: 1000000.0
+
+      - step: "Create the deduction document"
+        action: "create"
+        model: "school_scholarship_deduction"
+        save_as: "e2_deduction"
+        values:
+          award_id: "REC: e2_award.id"
+          date: 2026-08-05
+          journal_id: "REC: s_scholarship_journal.id"
+          receivable_account_id: "REC: s_receivable_account.id"
+          user_id: "REF: base.user_admin"
+          line_ids:
+            - - 0
+              - 0
+              - schedule_id: "REC: e2_schedule.id"
+                funding_id: "REC: e2_funding.id"
+                final_account_id: "REC: s_discount_account.id"
+                name: "E2 Deduction Line"
+                uom_quantity: 1
+                price_unit: 400000.0
+          allocation_ids:
+            - - 0
+              - 0
+              - customer_invoice_id: "REC: e2_invoice.id"
+                amount_allocated: 400000.0
+
+      - step: "Confirm the deduction"
+        action: "call"
+        target: "e2_deduction"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+        refresh: true
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
+
+      - step: "Invalidate cache before approving (avoids stale policy cache)"
+        action: "call"
+        target: "e2_deduction"
+        method: "invalidate_cache"
+
+      - step: "Approve the deduction, reconciling 400000 off the invoice"
+        action: "call"
+        target: "e2_deduction"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        refresh: true
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+      - step: "Assert the split fields right after the deduction opens"
+        action: "assert"
+        target: "e2_invoice"
+        refresh: true
+        asserts:
+          amount_residual:
+            type: "value"
+            expected: 600000.0
+          amount_settled_by_scholarship:
+            type: "value"
+            expected: 400000.0
+          amount_settled_by_cash:
+            type: "value"
+            expected: 0.0
+          has_scholarship:
+            type: "value"
+            expected: true
+          scholarship_deduction_ids:
+            type: "m2m"
+            check: "contains"
+            expected_records:
+              - "REC: e2_deduction"
+
+      - step: "Create the journal entry for the 600000 cash deposit"
+        action: "create"
+        model: "account.move"
+        save_as: "e2_bank_move"
+        values:
+          journal_id: "REC: s_bank_journal.id"
+          date: 2026-08-10
+          line_ids:
+            - - 0
+              - 0
+              - account_id: "REC: s_bank_account.id"
+                name: "E2 Cash Deposit - Bank"
+                partner_id: "REC: s_contact.id"
+                debit: 600000.0
+                credit: 0.0
+            - - 0
+              - 0
+              - account_id: "REC: s_receivable_account.id"
+                name: "E2 Cash Deposit - Receivable"
+                partner_id: "REC: s_contact.id"
+                debit: 0.0
+                credit: 600000.0
+
+      - step: "Post the cash deposit journal entry"
+        action: "call"
+        target: "e2_bank_move"
+        method: "action_post"
+
+      - step: "Find the deposit's own credit line on the receivable account"
+        action: "search"
+        model: "account.move.line"
+        domain:
+          [
+            ["move_id", "=", "REC: e2_bank_move.id"],
+            ["credit", "=", 600000.0],
+          ]
+        limit: 1
+        save_as: "e2_bank_credit_line"
+
+      - step: "Combine the invoice's own receivable line with the deposit's own credit line"
+        action: "search"
+        model: "account.move.line"
+        domain:
+          [
+            [
+              "id",
+              "in",
+              ["REC: e2_invoice.receivable_move_line_id.id", "REC: e2_bank_credit_line.id"],
+            ],
+          ]
+        save_as: "e2_combined_lines"
+
+      - step: "Reconcile the deposit against the invoice's remaining residual"
+        action: "call"
+        target: "e2_combined_lines"
+        method: "reconcile"
+
+      - step: "Assert the cash top-up settles the residual, scholarship unchanged"
+        action: "assert"
+        target: "e2_invoice"
+        refresh: true
+        asserts:
+          amount_residual:
+            type: "value"
+            expected: 0.0
+          amount_settled_by_scholarship:
+            type: "value"
+            expected: 400000.0
+          amount_settled_by_cash:
+            type: "value"
+            expected: 600000.0
+          has_scholarship:
+            type: "value"
+            expected: true
+
+      - step: "Create the cancellation reason"
+        action: "create"
+        model: "base.cancel_reason"
+        save_as: "e2_reason"
+        values:
+          name: "E2 Cancel Reason"
+          code: "E2CR"
+
+      - step: "Cancel the deduction via the wizard"
+        action: "wizard"
+        model: "base.select_cancel_reason"
+        target: "e2_deduction"
+        as_user: "base.user_admin"
+        values:
+          cancel_reason_id: "REC: e2_reason.id"
+        method: "action_confirm"
+        asserts:
+          state:
+            type: "value"
+            expected: "cancel"
+
+      - step: "Assert cancelling the deduction zeroes the scholarship split back out"
+        action: "assert"
+        target: "e2_invoice"
+        refresh: true
+        asserts:
+          amount_settled_by_scholarship:
+            type: "value"
+            expected: 0.0
+          amount_settled_by_cash:
+            type: "value"
+            expected: 600000.0
+          has_scholarship:
+            type: "value"
+            expected: false
+
+  # ══════════════════════════════════════════════════════════════════
+  # Positive (compute, most risk-loaded): an invoice fully covered by
+  # a scholarship reaches Paid (``done``) without a single unit of
+  # cash moving -- ``amount_settled_by_cash`` must still read zero.
+  # ══════════════════════════════════════════════════════════════════
+  - name: "Invoice Fully Covered By Scholarship Stays Zero Cash, Even When Paid"
+    steps:
+      - step: "Create the award backing the full deduction"
+        action: "create"
+        model: "school_scholarship_award"
+        save_as: "e3_award"
+        values:
+          program_id: "REC: s_program.id"
+          student_id: "REC: s_student.id"
+          enrollment_id: "REC: s_enrollment.id"
+          date_start: 2026-07-01
+          date_end: 2026-12-31
+          benefit_ids:
+            - - 0
+              - 0
+              - name: "E3 Benefit"
+                product_id: "REC: s_product.id"
+                benefit_type: "cash"
+                computation: "fixed"
+                amount_fixed: 1000000.0
+                periodicity: "one_time"
+          funding_ids:
+            - - 0
+              - 0
+              - funding_source_id: "REC: s_funding_source.id"
+                percentage: 100.0
+
+      - step: "Find the award's Benefit line"
+        action: "search"
+        model: "school_scholarship_award_benefit"
+        domain: [["award_id", "=", "REC: e3_award.id"]]
+        limit: 1
+        save_as: "e3_benefit"
+
+      - step: "Find the award's Funding line"
+        action: "search"
+        model: "school_scholarship_award_funding"
+        domain: [["award_id", "=", "REC: e3_award.id"]]
+        limit: 1
+        save_as: "e3_funding"
+
+      - step: "Create the Schedule line realizing the Benefit"
+        action: "create"
+        model: "school_scholarship_award_schedule"
+        save_as: "e3_schedule"
+        values:
+          benefit_id: "REC: e3_benefit.id"
+          date: 2026-08-01
+          state: "scheduled"
+
+      - step: "Create the invoice the full deduction is allocated against"
+        action: "create"
+        model: "customer_invoice"
+        save_as: "e3_invoice"
+        values:
+          type_id: "REC: s_invoice_type.id"
+          partner_id: "REC: s_contact.id"
+          date: 2026-08-01
+          date_due: 2026-08-15
+          currency_id: "REC: company.currency_id.id"
+          journal_id: "REC: s_invoice_journal.id"
+          receivable_account_id: "REC: s_receivable_account.id"
+          user_id: "REF: base.user_admin"
+
+      - step: "Add a detail line to the invoice"
+        action: "create"
+        model: "customer_invoice.line"
+        save_as: "e3_invoice_line"
+        values:
+          customer_invoice_id: "REC: e3_invoice.id"
+          name: "E3 Invoice Line"
+          account_id: "REC: s_income_account.id"
+          uom_quantity: 1
+          price_unit: 1000000.0
+
+      - step: "Confirm the invoice"
+        action: "call"
+        target: "e3_invoice"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+        refresh: true
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
+
+      - step: "Approve the invoice, posting its journal entry"
+        action: "call"
+        target: "e3_invoice"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        refresh: true
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+      - step: "Create the full deduction document"
+        action: "create"
+        model: "school_scholarship_deduction"
+        save_as: "e3_deduction"
+        values:
+          award_id: "REC: e3_award.id"
+          date: 2026-08-05
+          journal_id: "REC: s_scholarship_journal.id"
+          receivable_account_id: "REC: s_receivable_account.id"
+          user_id: "REF: base.user_admin"
+          line_ids:
+            - - 0
+              - 0
+              - schedule_id: "REC: e3_schedule.id"
+                funding_id: "REC: e3_funding.id"
+                final_account_id: "REC: s_discount_account.id"
+                name: "E3 Deduction Line"
+                uom_quantity: 1
+                price_unit: 1000000.0
+          allocation_ids:
+            - - 0
+              - 0
+              - customer_invoice_id: "REC: e3_invoice.id"
+                amount_allocated: 1000000.0
+
+      - step: "Confirm the full deduction"
+        action: "call"
+        target: "e3_deduction"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+        refresh: true
+
+      - step: "Invalidate cache before approving the full deduction"
+        action: "call"
+        target: "e3_deduction"
+        method: "invalidate_cache"
+
+      - step: "Approve the full deduction, fully reconciling the invoice"
+        action: "call"
+        target: "e3_deduction"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        refresh: true
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+          reconciled:
+            type: "value"
+            expected: true
+
+      - step: "Assert the invoice reached Paid with zero cash settled"
+        action: "assert"
+        target: "e3_invoice"
+        refresh: true
+        asserts:
+          state:
+            type: "value"
+            expected: "done"
+          amount_residual:
+            type: "value"
+            expected: 0.0
+          amount_settled_by_scholarship:
+            type: "value"
+            expected: 1000000.0
+          amount_settled_by_cash:
+            type: "value"
+            expected: 0.0
+          has_scholarship:
+            type: "value"
+            expected: true
+
+  # ══════════════════════════════════════════════════════════════════
+  # Negative paths: a credit from a bank journal must never be
+  # mistaken for a scholarship, whether it comes from the student's
+  # own contact or from an unrelated sponsor.
+  # ══════════════════════════════════════════════════════════════════
+  - name: "Bank-Only Settlement Never Counts As Scholarship"
+    steps:
+      # ── Negative: settled entirely by the student's own bank
+      # deposit, no deduction at all ──────────────────────────────────
+      - step: "Create the invoice settled purely by a bank deposit"
+        action: "create"
+        model: "customer_invoice"
+        save_as: "e4_invoice_own"
+        values:
+          type_id: "REC: s_invoice_type.id"
+          partner_id: "REC: s_contact.id"
+          date: 2026-08-01
+          date_due: 2026-08-15
+          currency_id: "REC: company.currency_id.id"
+          journal_id: "REC: s_invoice_journal.id"
+          receivable_account_id: "REC: s_receivable_account.id"
+          user_id: "REF: base.user_admin"
+
+      - step: "Add a detail line to the bank-only invoice"
+        action: "create"
+        model: "customer_invoice.line"
+        save_as: "e4_invoice_own_line"
+        values:
+          customer_invoice_id: "REC: e4_invoice_own.id"
+          name: "E4 Own Invoice Line"
+          account_id: "REC: s_income_account.id"
+          uom_quantity: 1
+          price_unit: 1000000.0
+
+      - step: "Confirm the bank-only invoice"
+        action: "call"
+        target: "e4_invoice_own"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+        refresh: true
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
+
+      - step: "Approve the bank-only invoice"
+        action: "call"
+        target: "e4_invoice_own"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        refresh: true
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+      - step: "Create the journal entry for the full 1000000 cash deposit"
+        action: "create"
+        model: "account.move"
+        save_as: "e4_own_bank_move"
+        values:
+          journal_id: "REC: s_bank_journal.id"
+          date: 2026-08-10
+          line_ids:
+            - - 0
+              - 0
+              - account_id: "REC: s_bank_account.id"
+                name: "E4 Own Cash Deposit - Bank"
+                partner_id: "REC: s_contact.id"
+                debit: 1000000.0
+                credit: 0.0
+            - - 0
+              - 0
+              - account_id: "REC: s_receivable_account.id"
+                name: "E4 Own Cash Deposit - Receivable"
+                partner_id: "REC: s_contact.id"
+                debit: 0.0
+                credit: 1000000.0
+
+      - step: "Post the full cash deposit"
+        action: "call"
+        target: "e4_own_bank_move"
+        method: "action_post"
+
+      - step: "Find the deposit's own credit line"
+        action: "search"
+        model: "account.move.line"
+        domain:
+          [
+            ["move_id", "=", "REC: e4_own_bank_move.id"],
+            ["credit", "=", 1000000.0],
+          ]
+        limit: 1
+        save_as: "e4_own_credit_line"
+
+      - step: "Combine the invoice's own receivable line with the deposit's own credit line"
+        action: "search"
+        model: "account.move.line"
+        domain:
+          [
+            [
+              "id",
+              "in",
+              [
+                "REC: e4_invoice_own.receivable_move_line_id.id",
+                "REC: e4_own_credit_line.id",
+              ],
+            ],
+          ]
+        save_as: "e4_own_combined_lines"
+
+      - step: "Reconcile the full deposit against the invoice"
+        action: "call"
+        target: "e4_own_combined_lines"
+        method: "reconcile"
+
+      - step: "Assert a bank-only settlement never counts as scholarship"
+        action: "assert"
+        target: "e4_invoice_own"
+        refresh: true
+        asserts:
+          amount_residual:
+            type: "value"
+            expected: 0.0
+          amount_settled_by_scholarship:
+            type: "value"
+            expected: 0.0
+          amount_settled_by_cash:
+            type: "value"
+            expected: 1000000.0
+          has_scholarship:
+            type: "value"
+            expected: false
+
+      # ── Negative: settled by a sponsor's bank deposit -- a
+      # third-party payment is still a cash settlement, not a
+      # scholarship deduction ─────────────────────────────────────────
+      - step: "Create the invoice settled by a sponsor's bank deposit"
+        action: "create"
+        model: "customer_invoice"
+        save_as: "e4_invoice_sponsor"
+        values:
+          type_id: "REC: s_invoice_type.id"
+          partner_id: "REC: s_contact.id"
+          date: 2026-08-01
+          date_due: 2026-08-15
+          currency_id: "REC: company.currency_id.id"
+          journal_id: "REC: s_invoice_journal.id"
+          receivable_account_id: "REC: s_receivable_account.id"
+          user_id: "REF: base.user_admin"
+
+      - step: "Add a detail line to the sponsor-paid invoice"
+        action: "create"
+        model: "customer_invoice.line"
+        save_as: "e4_invoice_sponsor_line"
+        values:
+          customer_invoice_id: "REC: e4_invoice_sponsor.id"
+          name: "E4 Sponsor Invoice Line"
+          account_id: "REC: s_income_account.id"
+          uom_quantity: 1
+          price_unit: 1000000.0
+
+      - step: "Confirm the sponsor-paid invoice"
+        action: "call"
+        target: "e4_invoice_sponsor"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+        refresh: true
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
+
+      - step: "Approve the sponsor-paid invoice"
+        action: "call"
+        target: "e4_invoice_sponsor"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        refresh: true
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+      - step: "Create the journal entry for the sponsor's cash deposit"
+        action: "create"
+        model: "account.move"
+        save_as: "e4_sponsor_bank_move"
+        values:
+          journal_id: "REC: s_bank_journal.id"
+          date: 2026-08-10
+          line_ids:
+            - - 0
+              - 0
+              - account_id: "REC: s_bank_account.id"
+                name: "E4 Sponsor Cash Deposit - Bank"
+                partner_id: "REC: s_sponsor_contact.id"
+                debit: 1000000.0
+                credit: 0.0
+            - - 0
+              - 0
+              - account_id: "REC: s_receivable_account.id"
+                name: "E4 Sponsor Cash Deposit - Receivable"
+                partner_id: "REC: s_sponsor_contact.id"
+                debit: 0.0
+                credit: 1000000.0
+
+      - step: "Post the sponsor's cash deposit"
+        action: "call"
+        target: "e4_sponsor_bank_move"
+        method: "action_post"
+
+      - step: "Find the sponsor deposit's own credit line"
+        action: "search"
+        model: "account.move.line"
+        domain:
+          [
+            ["move_id", "=", "REC: e4_sponsor_bank_move.id"],
+            ["credit", "=", 1000000.0],
+          ]
+        limit: 1
+        save_as: "e4_sponsor_credit_line"
+
+      - step: "Combine the invoice's own receivable line with the sponsor's credit line"
+        action: "search"
+        model: "account.move.line"
+        domain:
+          [
+            [
+              "id",
+              "in",
+              [
+                "REC: e4_invoice_sponsor.receivable_move_line_id.id",
+                "REC: e4_sponsor_credit_line.id",
+              ],
+            ],
+          ]
+        save_as: "e4_sponsor_combined_lines"
+
+      - step: "Reconcile the sponsor's deposit against the invoice"
+        action: "call"
+        target: "e4_sponsor_combined_lines"
+        method: "reconcile"
+
+      - step: "Assert a sponsor's bank settlement never counts as scholarship"
+        action: "assert"
+        target: "e4_invoice_sponsor"
+        refresh: true
+        asserts:
+          amount_residual:
+            type: "value"
+            expected: 0.0
+          amount_settled_by_scholarship:
+            type: "value"
+            expected: 0.0
+          amount_settled_by_cash:
+            type: "value"
+            expected: 1000000.0
+          has_scholarship:
+            type: "value"
+            expected: false

--- a/ssi_school_scholarship_deduction/views/customer_invoice.xml
+++ b/ssi_school_scholarship_deduction/views/customer_invoice.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+<record id="customer_invoice_view_form_scholarship_deduction" model="ir.ui.view">
+    <field name="name">customer_invoice - form - scholarship deduction</field>
+    <field name="model">customer_invoice</field>
+    <field name="inherit_id" ref="ssi_customer_invoice.customer_invoice_view_form" />
+    <field name="arch" type="xml">
+        <data>
+            <xpath expr="//field[@name='amount_residual']" position="after">
+                <field name="amount_settled_by_scholarship" />
+                <field name="amount_settled_by_cash" />
+            </xpath>
+        </data>
+    </field>
+</record>
+
+<record
+        id="customer_invoice_view_search_scholarship_deduction"
+        model="ir.ui.view"
+    >
+    <field name="name">customer_invoice - search - scholarship deduction</field>
+    <field name="model">customer_invoice</field>
+    <field
+            name="inherit_id"
+            ref="ssi_customer_invoice.customer_invoice_view_search"
+        />
+    <field name="arch" type="xml">
+        <data>
+            <xpath expr="//filter[@name='dom_my_data']" position="after">
+                <filter
+                        name="dom_has_scholarship"
+                        string="Has Scholarship"
+                        domain="[('has_scholarship', '=', True)]"
+                    />
+            </xpath>
+        </data>
+    </field>
+</record>
+</odoo>

--- a/ssi_school_scholarship_deduction/views/customer_invoice.xml
+++ b/ssi_school_scholarship_deduction/views/customer_invoice.xml
@@ -17,16 +17,10 @@
     </field>
 </record>
 
-<record
-        id="customer_invoice_view_search_scholarship_deduction"
-        model="ir.ui.view"
-    >
+<record id="customer_invoice_view_search_scholarship_deduction" model="ir.ui.view">
     <field name="name">customer_invoice - search - scholarship deduction</field>
     <field name="model">customer_invoice</field>
-    <field
-            name="inherit_id"
-            ref="ssi_customer_invoice.customer_invoice_view_search"
-        />
+    <field name="inherit_id" ref="ssi_customer_invoice.customer_invoice_view_search" />
     <field name="arch" type="xml">
         <data>
             <xpath expr="//filter[@name='dom_my_data']" position="after">


### PR DESCRIPTION
## Ringkasan

- Tambah field compute pada `customer_invoice` (glue `_name`+`_inherit`):
  `scholarship_deduction_ids`, `amount_settled_by_scholarship`,
  `amount_settled_by_cash`, `has_scholarship` — memisahkan penyelesaian
  piutang oleh beasiswa dari setoran kas tanpa hardcode nama jurnal
  (jurnal beasiswa diidentifikasi lewat `journal_id` dokumen potongan
  yang terkait).
- Tampilkan `amount_settled_by_scholarship` dan `amount_settled_by_cash`
  di form tagihan, tambah filter "Has Scholarship" di search view.
- Tambah kolom `amount_scholarship`, `amount_gross`, `amount_net` pada
  SQL view `school_enrollment_fee_analysis` (`ssi_school`) lewat
  override `_select_query()`, tanpa menulis ulang query aslinya.
- Skenario uji `odoo-yaml-test` menutup seluruh kasus compute, reversal
  saat pembatalan dokumen potongan, dan negative path (kredit dari
  jurnal bank — termasuk pembayaran sponsor — tidak boleh terhitung
  sebagai beasiswa).
- Modul `ssi_customer_invoice` tidak disentuh sama sekali.

## Test plan

- [x] `assets/verify-module.sh` mencetak `LOLOS: 0 ERROR`
- [ ] CI hijau (pre-commit + unit test)

Closes #11