### PR TITLE
[UPD] ssi_school_scholarship - Pindahkan grup config beasiswa ke Configuration milik ssi_school

### DIFF
--- a/ssi_school_scholarship/docs/school_scholarship_funding_source/01-create.md
+++ b/ssi_school_scholarship/docs/school_scholarship_funding_source/01-create.md
@@ -2,7 +2,7 @@
 
 > **Module:** ssi_school_scholarship\
 > **Model:** `school_scholarship_funding_source`\
-> **Menu:** School > Scholarship > Configuration > Scholarship Funding Sources\
+> **Menu:** School > Configuration > Scholarship > Scholarship Funding Sources\
 > **Actor:** user in group `Scholarship Funding Source`\
 > **Inline Actions:** `action_generate_code` (Generate Code)
 
@@ -16,7 +16,7 @@
 
 ## Flow
 
-1. Open the **School > Scholarship > Configuration > Scholarship Funding Sources** menu.
+1. Open the **School > Configuration > Scholarship > Scholarship Funding Sources** menu.
 2. Click the **New** button. **(14.0: "Create")**
 3. Fill in the required fields:
    - **Name** _(required)_: Enter the name of the funding source (e.g. "Foundation Grant

--- a/ssi_school_scholarship/docs/school_scholarship_program/01-create.md
+++ b/ssi_school_scholarship/docs/school_scholarship_program/01-create.md
@@ -2,7 +2,7 @@
 
 > **Module:** ssi_school_scholarship\
 > **Model:** `school_scholarship_program`\
-> **Menu:** School > Scholarship > Configuration > Scholarship Programs\
+> **Menu:** School > Configuration > Scholarship > Scholarship Programs\
 > **Actor:** user in group `Scholarship Program`\
 > **Inline Actions:** `action_generate_code` (Generate Code)
 
@@ -18,7 +18,7 @@
 
 ## Flow
 
-1. Open the **School > Scholarship > Configuration > Scholarship Programs** menu.
+1. Open the **School > Configuration > Scholarship > Scholarship Programs** menu.
 2. Click the **New** button. **(14.0: "Create")**
 3. Fill in the required fields:
    - **Name** _(required)_: Enter the name of the program (e.g. "2026/2027 Need-Based

--- a/ssi_school_scholarship/docs/school_scholarship_type/01-create.md
+++ b/ssi_school_scholarship/docs/school_scholarship_type/01-create.md
@@ -2,7 +2,7 @@
 
 > **Module:** ssi_school_scholarship\
 > **Model:** `school_scholarship_type`\
-> **Menu:** School > Scholarship > Configuration > Scholarship Types\
+> **Menu:** School > Configuration > Scholarship > Scholarship Types\
 > **Actor:** user in group `Scholarship Type`\
 > **Inline Actions:** `action_generate_code` (Generate Code)
 
@@ -16,7 +16,7 @@
 
 ## Flow
 
-1. Open the **School > Scholarship > Configuration > Scholarship Types** menu.
+1. Open the **School > Configuration > Scholarship > Scholarship Types** menu.
 2. Click the **New** button. **(14.0: "Create")**
 3. Fill in the required fields:
    - **Name** _(required)_: Enter the name of the scholarship type (e.g. "Full

--- a/ssi_school_scholarship/menu.xml
+++ b/ssi_school_scholarship/menu.xml
@@ -12,9 +12,9 @@
 
 <menuitem
         id="menu_school_scholarship_configuration"
-        name="Configuration"
-        parent="menu_school_scholarship"
-        sequence="99"
+        name="Scholarship"
+        parent="ssi_school.menu_school_configuration"
+        sequence="170"
     />
 
 </odoo>

--- a/ssi_school_scholarship/static/tests/tours/school_scholarship_funding_source_tour.js
+++ b/ssi_school_scholarship/static/tests/tours/school_scholarship_funding_source_tour.js
@@ -17,8 +17,8 @@ odoo.define("ssi_school_scholarship.school_scholarship_funding_source_tour", fun
             url: "/web",
         },
         [
-            // ── Flow 1 — Open the School > Scholarship > Configuration >
-            // Scholarship Funding Sources menu. "Configuration"
+            // ── Flow 1 — Open the School > Configuration > Scholarship >
+            // Scholarship Funding Sources menu. "Scholarship"
             // (menu_school_scholarship_configuration) is a level-3
             // grouping menuitem with no action= attribute, so 14.0
             // renders it as a non-clickable dropdown header without
@@ -30,9 +30,9 @@ odoo.define("ssi_school_scholarship.school_scholarship_funding_source_tour", fun
                 trigger: '.o_app[data-menu-xmlid="ssi_school.menu_school_root"]',
             },
             {
-                content: "Open the Scholarship menu",
+                content: "Open the Configuration menu",
                 trigger:
-                    '.o_menu_sections [data-menu-xmlid="ssi_school_scholarship.menu_school_scholarship"]',
+                    '.o_menu_sections [data-menu-xmlid="ssi_school.menu_school_configuration"]',
             },
             {
                 content: "Open the Scholarship Funding Sources menu",

--- a/ssi_school_scholarship/static/tests/tours/school_scholarship_program_tour.js
+++ b/ssi_school_scholarship/static/tests/tours/school_scholarship_program_tour.js
@@ -17,8 +17,8 @@ odoo.define("ssi_school_scholarship.school_scholarship_program_tour", function (
             url: "/web",
         },
         [
-            // ── Flow 1 — Open the School > Scholarship > Configuration >
-            // Scholarship Programs menu. "Configuration"
+            // ── Flow 1 — Open the School > Configuration > Scholarship >
+            // Scholarship Programs menu. "Scholarship"
             // (menu_school_scholarship_configuration) is a level-3 grouping
             // menuitem with no action= attribute, so 14.0 renders it as a
             // non-clickable dropdown header without data-menu-xmlid --
@@ -30,9 +30,9 @@ odoo.define("ssi_school_scholarship.school_scholarship_program_tour", function (
                 trigger: '.o_app[data-menu-xmlid="ssi_school.menu_school_root"]',
             },
             {
-                content: "Open the Scholarship menu",
+                content: "Open the Configuration menu",
                 trigger:
-                    '.o_menu_sections [data-menu-xmlid="ssi_school_scholarship.menu_school_scholarship"]',
+                    '.o_menu_sections [data-menu-xmlid="ssi_school.menu_school_configuration"]',
             },
             {
                 content: "Open the Scholarship Programs menu",

--- a/ssi_school_scholarship/static/tests/tours/school_scholarship_type_tour.js
+++ b/ssi_school_scholarship/static/tests/tours/school_scholarship_type_tour.js
@@ -15,8 +15,8 @@ odoo.define("ssi_school_scholarship.school_scholarship_type_tour", function (req
             url: "/web",
         },
         [
-            // ── Flow 1 — Open the School > Scholarship > Configuration >
-            // Scholarship Types menu. "Configuration"
+            // ── Flow 1 — Open the School > Configuration > Scholarship >
+            // Scholarship Types menu. "Scholarship"
             // (menu_school_scholarship_configuration) is a level-3 grouping
             // menuitem with no action= attribute, so 14.0 renders it as a
             // non-clickable dropdown header without data-menu-xmlid --
@@ -28,9 +28,9 @@ odoo.define("ssi_school_scholarship.school_scholarship_type_tour", function (req
                 trigger: '.o_app[data-menu-xmlid="ssi_school.menu_school_root"]',
             },
             {
-                content: "Open the Scholarship menu",
+                content: "Open the Configuration menu",
                 trigger:
-                    '.o_menu_sections [data-menu-xmlid="ssi_school_scholarship.menu_school_scholarship"]',
+                    '.o_menu_sections [data-menu-xmlid="ssi_school.menu_school_configuration"]',
             },
             {
                 content: "Open the Scholarship Types menu",

--- a/ssi_school_scholarship_operating_unit/static/tests/tours/school_scholarship_funding_source_tour.js
+++ b/ssi_school_scholarship_operating_unit/static/tests/tours/school_scholarship_funding_source_tour.js
@@ -27,17 +27,17 @@ odoo.define(
                 url: "/web",
             },
             [
-                // ── Base Flow 1 — Open the School > Scholarship >
-                // Configuration > Scholarship Funding Sources menu.
+                // ── Base Flow 1 — Open the School > Configuration >
+                // Scholarship > Scholarship Funding Sources menu.
                 tour.stepUtils.showAppsMenuItem(),
                 {
                     content: "Open the School app",
                     trigger: '.o_app[data-menu-xmlid="ssi_school.menu_school_root"]',
                 },
                 {
-                    content: "Open the Scholarship menu",
+                    content: "Open the Configuration menu",
                     trigger:
-                        '.o_menu_sections [data-menu-xmlid="ssi_school_scholarship.menu_school_scholarship"]',
+                        '.o_menu_sections [data-menu-xmlid="ssi_school.menu_school_configuration"]',
                 },
                 {
                     content: "Open the Scholarship Funding Sources menu",

--- a/ssi_school_scholarship_operating_unit/static/tests/tours/school_scholarship_program_tour.js
+++ b/ssi_school_scholarship_operating_unit/static/tests/tours/school_scholarship_program_tour.js
@@ -27,17 +27,17 @@ odoo.define(
                 url: "/web",
             },
             [
-                // ── Base Flow 1 — Open the School > Scholarship >
-                // Configuration > Scholarship Programs menu.
+                // ── Base Flow 1 — Open the School > Configuration >
+                // Scholarship > Scholarship Programs menu.
                 tour.stepUtils.showAppsMenuItem(),
                 {
                     content: "Open the School app",
                     trigger: '.o_app[data-menu-xmlid="ssi_school.menu_school_root"]',
                 },
                 {
-                    content: "Open the Scholarship menu",
+                    content: "Open the Configuration menu",
                     trigger:
-                        '.o_menu_sections [data-menu-xmlid="ssi_school_scholarship.menu_school_scholarship"]',
+                        '.o_menu_sections [data-menu-xmlid="ssi_school.menu_school_configuration"]',
                 },
                 {
                     content: "Open the Scholarship Programs menu",

--- a/ssi_school_scholarship_operating_unit/static/tests/tours/school_scholarship_type_tour.js
+++ b/ssi_school_scholarship_operating_unit/static/tests/tours/school_scholarship_type_tour.js
@@ -26,17 +26,17 @@ odoo.define(
                 url: "/web",
             },
             [
-                // ── Base Flow 1 — Open the School > Scholarship >
-                // Configuration > Scholarship Types menu.
+                // ── Base Flow 1 — Open the School > Configuration >
+                // Scholarship > Scholarship Types menu.
                 tour.stepUtils.showAppsMenuItem(),
                 {
                     content: "Open the School app",
                     trigger: '.o_app[data-menu-xmlid="ssi_school.menu_school_root"]',
                 },
                 {
-                    content: "Open the Scholarship menu",
+                    content: "Open the Configuration menu",
                     trigger:
-                        '.o_menu_sections [data-menu-xmlid="ssi_school_scholarship.menu_school_scholarship"]',
+                        '.o_menu_sections [data-menu-xmlid="ssi_school.menu_school_configuration"]',
                 },
                 {
                     content: "Open the Scholarship Types menu",


### PR DESCRIPTION
## Ringkasan

Memindahkan grup config beasiswa (`menu_school_scholarship_configuration`) agar
menjadi anak `ssi_school.menu_school_configuration`, bukan lagi anak section
operasional `Scholarship` milik modul ini sendiri. Seluruh master data beasiswa
(Programs, Types, Funding Sources) kini berada di bawah
`School > Configuration > Scholarship`, konsisten dengan preseden
`ssi_school_character` (`menu_character_configuration`).

* `parent` grup config → `ssi_school.menu_school_configuration`
* `name` grup config → "Scholarship" (bukan "Configuration")
* `sequence` grup config → `170`, menyambung urutan grup config app School yang
  sudah ada (Admission=10, Period=110, Grade=120, Subject & Scoring=130,
  Enrollment=140, Incident=150, Character Learning=160)
* XML ID `menu_school_scholarship_configuration` **tidak** diubah
* Blok metadata `Menu:` pada IK dan langkah navigasi tour ketiga model master
  data disesuaikan dengan jalur menu baru

## Referensi

Gate "Struktur menu" `verify-module.sh` (skill `odoo-development`) sekarang
lolos tanpa temuan untuk modul ini.

Closes #32