### PR TITLE
[UPD] ssi_school_scholarship - Gabungkan tab Deduction/Disbursement/Deferred Recognition award jadi tab Accounting

### DIFF
--- a/ssi_school_scholarship/docs/school_scholarship_award/01-create.md
+++ b/ssi_school_scholarship/docs/school_scholarship_award/01-create.md
@@ -22,8 +22,8 @@
 3. Fill in the required fields:
    - **Program** _(required)_: Select the scholarship program this award is granted
      under. Selecting it fills the Type, Academic Year, the nine accounting fields on
-     the **Deduction**, **Disbursement**, and **Deferred Recognition** tabs, and **Is
-     Employee Benefit** from the program's configuration.
+     the **Accounting** tab (Deduction, Disbursement, and Deferred Recognition groups),
+     and **Is Employee Benefit** from the program's configuration.
    - **Student** _(required)_: Select the student this award is granted to.
    - **Enrollment** _(required)_: Select the enrollment this award is billed against,
      restricted to enrollments of the selected Student.
@@ -62,9 +62,9 @@
 6. Optionally, on the **Letters** tab, add letters related to this award (Award Letter,
    Agreement, Revocation Letter, Renewal Letter). Attach the physical file of a letter
    on its own chatter after saving, rather than on a field.
-7. Review the accounting fields defaulted from the Program on the **Deduction**,
-   **Disbursement**, and **Deferred Recognition** tabs, and override any of them if this
-   award needs a different account or journal than its program.
+7. Review the accounting fields defaulted from the Program on the **Accounting** tab
+   (Deduction, Disbursement, and Deferred Recognition groups), and override any of them
+   if this award needs a different account or journal than its program.
 8. Click **Save**.
 
 ## Post-Condition

--- a/ssi_school_scholarship/static/tests/tours/school_scholarship_award_tour.js
+++ b/ssi_school_scholarship/static/tests/tours/school_scholarship_award_tour.js
@@ -73,7 +73,7 @@ odoo.define("ssi_school_scholarship.school_scholarship_award_tour", function (re
             // Date, End Date. Selecting Program triggers the onchange
             // that fills the nine accounting fields and Is Employee
             // Benefit in the background -- reviewed later in Flow 7,
-            // once the Deduction tab is actually open.
+            // once the Accounting tab is actually open.
             {
                 content: "Select the Program",
                 trigger: ".o_field_many2one[name='program_id'] input",
@@ -200,14 +200,15 @@ odoo.define("ssi_school_scholarship.school_scholarship_award_tour", function (re
             },
 
             // ── Flow 7 — Review the accounting fields defaulted from
-            // the Program on the Deduction tab. Opening the tab is
-            // required before its fields can be asserted: they render
-            // inside a Bootstrap `.tab-pane` kept `display:none` while
-            // a different tab is active, so `.o_external_button` never
-            // becomes `:visible` until this tab is opened.
+            // the Program on the Accounting tab (Deduction group).
+            // Opening the tab is required before its fields can be
+            // asserted: they render inside a Bootstrap `.tab-pane` kept
+            // `display:none` while a different tab is active, so
+            // `.o_external_button` never becomes `:visible` until this
+            // tab is opened.
             {
-                content: "Open the Deduction tab",
-                trigger: ".o_notebook .nav-link:contains(Deduction)",
+                content: "Open the Accounting tab",
+                trigger: ".o_notebook .nav-link:contains(Accounting)",
             },
             {
                 content: "Deduction Journal is filled by the onchange",

--- a/ssi_school_scholarship/views/school_scholarship_award.xml
+++ b/ssi_school_scholarship/views/school_scholarship_award.xml
@@ -216,27 +216,20 @@
                         </tree>
                     </field>
                 </page>
-                <page name="deduction" string="Deduction">
-                    <group name="deduction_group" string="Deduction Configuration">
+                <page name="accounting" string="Accounting">
+                    <group name="deduction_group" string="Deduction">
                         <field name="deduction_journal_id" />
                         <field name="discount_account_id" />
                         <field name="employee_benefit_account_id" />
                     </group>
-                </page>
-                <page name="disbursement" string="Disbursement">
-                    <group
-                            name="disbursement_group"
-                            string="Disbursement Configuration"
-                        >
+                    <group name="disbursement_group" string="Disbursement">
                         <field name="disbursement_journal_id" />
                         <field name="expense_account_id" />
                         <field name="payable_account_id" />
                     </group>
-                </page>
-                <page name="deferred_recognition" string="Deferred Recognition">
                     <group
                             name="deferred_recognition_group"
-                            string="Deferred Recognition Configuration"
+                            string="Deferred Recognition"
                         >
                         <field name="deferred_discount_account_id" />
                         <field name="deferred_expense_account_id" />


### PR DESCRIPTION
## Ringkasan

Menggabungkan tiga notebook page terpisah (`deduction`, `disbursement`,
`deferred_recognition`) pada form Scholarship Award menjadi satu page
`accounting` (string "Accounting") berisi tiga `<group>` berlabel
(`deduction_group`, `disbursement_group`, `deferred_recognition_group`).
Keanggotaan & urutan sembilan field tidak berubah. XML ID view dan nama
group dipertahankan.

- IK `docs/school_scholarship_award/01-create.md` (langkah 3 dan 7)
  diperbarui agar merujuk tab Accounting.
- Tour `school_scholarship_award_tour.js` diperbarui: step yang membuka
  tab Deduction sekarang membuka tab Accounting.

Tidak ada perubahan pada `models/`, `security/`, `__manifest__.py`, dan
tidak ada skenario unit test YAML baru (murni perubahan view — sesuai
Keputusan Desain issue).

## Temuan grep lintas-modul

Sesuai instruksi issue, dilakukan grep ulang di seluruh repo
`ssi-school-scholarship` (bukan hanya `ssi_school_scholarship`) sebelum
commit:

- `ssi_school_scholarship_deduction`, `ssi_school_scholarship_disbursement`,
  dan `ssi_school_scholarship_operating_unit` masing-masing memiliki view
  yang meng-inherit `school_scholarship_award_view_form`, tapi ketiganya
  **hanya** meng-xpath `//header` dan `//field[@name='company_id']` —
  klaim di issue terverifikasi benar, tidak ada view lain yang meng-xpath
  page `deduction`/`disbursement`/`deferred_recognition`.
- `ssi_school_scholarship_deduction_operating_unit` dan
  `ssi_school_scholarship_disbursement_operating_unit` tidak punya berkas
  terkait `school_scholarship_award` sama sekali.
- Tidak ada tour lain (di modul manapun) yang mengklik
  `.o_notebook .nav-link:contains(Deduction)` /
  `:contains(Disbursement)` / `:contains(Deferred Recognition)` pada form
  **Award**. String "Deduction"/"Disbursement" memang muncul di beberapa
  tour lain, tetapi merujuk model/menu berbeda (mis. breadcrumb "Scholarship
  Disbursements", tombol "Create Due Deduction"), bukan tab pada form Award.
- `school_scholarship_program.xml` dan `school_scholarship_type.xml` masih
  memiliki tiga tab serupa (beserta IK & tour-nya) — **sengaja tidak
  disentuh**, sesuai bagian "Tidak termasuk" pada issue #33.

Tidak ada modul lain yang perlu diikutsertakan dalam PR ini.

## Validasi

```
#VALIDATOR name=module target=ssi_school_scholarship series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=ik target=ssi_school_scholarship series=14.0 error=0 warn=1 defer=0 excepted=0 status=OK
#VALIDATOR name=tour target=ssi_school_scholarship series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
```

(1 peringatan IK adalah temuan warisan — `action_open_scholarship_award`
tanpa rumah di docs/ — tidak diperkenalkan oleh perubahan ini, diverifikasi
lewat `vs-head.sh`.)

Closes #33