### PR TITLE
[UPD] ssi_school_scholarship - Jadikan Award & Schedule agnostik terhadap sumber penagihan

### DIFF
--- a/ssi_school_scholarship/__manifest__.py
+++ b/ssi_school_scholarship/__manifest__.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     "name": "School Scholarship",
-    "version": "14.0.1.5.2",
+    "version": "14.0.1.6.0",
     "website": "https://simetri-sinergi.id",
     # pylint: disable=line-too-long
     "author": "PT. Simetri Sinergi Indonesia, OpenSynergy Indonesia, Odoo Community Association (OCA)",  # noqa: B950

--- a/ssi_school_scholarship/docs/school_scholarship_award/01-create.md
+++ b/ssi_school_scholarship/docs/school_scholarship_award/01-create.md
@@ -25,8 +25,11 @@
      the **Accounting** tab (Deduction, Disbursement, and Deferred Recognition groups),
      and **Is Employee Benefit** from the program's configuration.
    - **Student** _(required)_: Select the student this award is granted to.
-   - **Enrollment** _(required)_: Select the enrollment this award is billed against,
-     restricted to enrollments of the selected Student.
+   - **Billing Source** _(required)_: Select the billing source this award is billed
+     against. Defaults to **Enrollment**, the only value this module registers.
+   - **Enrollment** _(required when Billing Source is Enrollment)_: Select the
+     enrollment this award is billed against, restricted to enrollments of the selected
+     Student. Hidden when Billing Source is not Enrollment.
    - **Start Date** _(required)_: Enter the first period this award applies to.
    - **End Date** _(required)_: Enter the last period this award applies to. Must not be
      earlier than Start Date.

--- a/ssi_school_scholarship/migrations/14.0.1.6.0/post-migration.py
+++ b/ssi_school_scholarship/migrations/14.0.1.6.0/post-migration.py
@@ -1,0 +1,48 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+#
+# Migration: 14.0.1.5.2 -> 14.0.1.6.0
+#
+# Changes: school_scholarship_award gained a new required column,
+#          source_type, discriminating the billing source an award is
+#          billed against (this release only registers "enrollment").
+#          Odoo's own _init_column already backfills every existing
+#          row with the field's default ("enrollment") as soon as the
+#          column is created, before this script ever runs. This
+#          script is deliberately defensive: it makes that backfill
+#          explicit and auditable on a live database (25 open awards)
+#          rather than relying on it having happened silently, and
+#          logs how many rows it touched.
+
+import logging
+
+from openupgradelib import openupgrade
+
+_logger = logging.getLogger(__name__)
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    """Stamp ``source_type='enrollment'`` on every pre-existing award.
+
+    Explicit and auditable stand-in for the backfill Odoo's own
+    ``_init_column`` already performs silently when the column is
+    created.
+
+    :param env: the migration environment
+    :param version: the version being migrated to (unused)
+    :return: nothing; updates ``school_scholarship_award`` rows
+    """
+    openupgrade.logged_query(
+        env.cr,
+        """
+        UPDATE school_scholarship_award
+        SET source_type = 'enrollment'
+        WHERE source_type IS NULL
+        """,
+    )
+    _logger.info(
+        "Stamped source_type='enrollment' on %s school_scholarship_award " "row(s).",
+        env.cr.rowcount,
+    )

--- a/ssi_school_scholarship/models/school_scholarship_award.py
+++ b/ssi_school_scholarship/models/school_scholarship_award.py
@@ -157,10 +157,27 @@ class SchoolScholarshipAward(models.Model):
         "billed on the student's invoices so the deduction created "
         "by a later document can be reconciled against it.",
     )
+    source_type = fields.Selection(
+        string="Billing Source",
+        selection=[
+            ("enrollment", "Enrollment"),
+        ],
+        default="enrollment",
+        required=True,
+        readonly=True,
+        states={
+            "draft": [
+                ("readonly", False),
+            ],
+        },
+        help="Billing source this award is billed against. This "
+        "module only registers Enrollment -- extension modules add "
+        "further values with ``selection_add`` and override the "
+        "``_get_source_*`` hooks to match.",
+    )
     enrollment_id = fields.Many2one(
         string="Enrollment",
         comodel_name="school_enrollment",
-        required=True,
         ondelete="restrict",
         readonly=True,
         states={
@@ -169,23 +186,28 @@ class SchoolScholarshipAward(models.Model):
             ],
         },
         help="Enrollment this award is billed against. Must belong to "
-        "the selected Student.",
+        "the selected Student. Required when Billing Source is "
+        "Enrollment -- enforced by ``_check_billing_source``, not by "
+        "this field itself, so an extension module's own billing "
+        "source is not forced to also be a required field.",
     )
     school_id = fields.Many2one(
         string="School",
         comodel_name="school",
-        related="enrollment_id.school_id",
+        compute="_compute_school_id",
         store=True,
+        compute_sudo=True,
         readonly=True,
-        help="School of the selected enrollment.",
+        help="School of the selected billing source.",
     )
     grade_id = fields.Many2one(
         string="Grade",
         comodel_name="school_grade",
-        related="enrollment_id.grade_id",
+        compute="_compute_grade_id",
         store=True,
+        compute_sudo=True,
         readonly=True,
-        help="Grade of the selected enrollment.",
+        help="Grade of the selected billing source.",
     )
     academic_year_id = fields.Many2one(
         string="Academic Year",
@@ -510,6 +532,33 @@ class SchoolScholarshipAward(models.Model):
         "policy field is wired up in advance.",
     )
 
+    @api.depends("enrollment_id")
+    def _compute_school_id(self):
+        """Derive the School from this award's billing source.
+
+        Extension point: a module registering another Billing Source
+        value declares a new method decorated with its own
+        ``@api.depends`` (e.g. ``"admission_id"``) that calls
+        ``super()`` first, so this method's own ``enrollment_id``
+        dependency keeps working unmodified.
+
+        :return: nothing; assigns ``school_id``
+        """
+        for record in self:
+            record.school_id = record._get_source_record().school_id
+
+    @api.depends("enrollment_id")
+    def _compute_grade_id(self):
+        """Derive the Grade from this award's billing source.
+
+        See ``_compute_school_id`` for the extension pattern this
+        method follows.
+
+        :return: nothing; assigns ``grade_id``
+        """
+        for record in self:
+            record.grade_id = record._get_source_record().grade_id
+
     @api.depends("schedule_ids.amount_planned", "schedule_ids.state")
     def _compute_amount_awarded(self):
         """Sum the Schedule lines into the award's committed amount.
@@ -674,16 +723,49 @@ Solution: Select an End Date on or after Start Date
                 )
                 raise ValidationError(_(error_message))
 
-    @api.constrains("enrollment_id", "student_id")
+    @api.constrains("source_type", "enrollment_id")
+    def _check_billing_source(self):
+        """Require a billing source record for the selected source type.
+
+        The requiredness of ``enrollment_id`` moved here from the
+        field's own ``required`` attribute so an extension module's
+        Billing Source value is not forced to also key off
+        ``enrollment_id``: each value's own source field is validated
+        through ``_get_source_record()`` instead.
+
+        :raises ValidationError: when ``_get_source_record()`` is
+            empty.
+        """
+        for record in self:
+            if not record._get_source_record():
+                error_message = """
+Document Type: %s
+Context: Set award billing source
+Database ID: %s
+Problem: No billing source record set for Billing Source '%s'
+Solution: Select the record matching the selected Billing Source
+""" % (
+                    record._description,
+                    record.id,
+                    record.source_type,
+                )
+                raise ValidationError(_(error_message))
+
+    @api.constrains("enrollment_id", "student_id", "source_type")
     def _check_enrollment_student(self):
         """Require the Enrollment to belong to the selected Student.
+
+        Guarded to Billing Source Enrollment: an extension module's
+        billing source is not billed against an Enrollment at all, so
+        this check has nothing to compare for it.
 
         :raises ValidationError: when ``enrollment_id.student_id`` is
             not the same as ``student_id``.
         """
         for record in self:
             if (
-                record.enrollment_id
+                record.source_type == "enrollment"
+                and record.enrollment_id
                 and record.student_id
                 and record.enrollment_id.student_id != record.student_id
             ):
@@ -703,24 +785,21 @@ Solution: Select an Enrollment that belongs to the selected Student
 
     @api.constrains("company_currency_id", "enrollment_id")
     def _check_currency(self):
-        """Require the award's currency to match the enrollment's.
+        """Require the award's currency to match its billing source's.
 
         The award carries no standalone ``currency_id`` of its own —
         ``company_currency_id`` (from ``mixin.company_currency``) is
         the field the Benefit/Funding Monetary amounts are expressed
-        in, and it must match the currency the enrollment is billed
-        in for the eventual deduction to reconcile against the
+        in, and it must match the currency the billing source is
+        billed in for the eventual deduction to reconcile against the
         invoice.
 
-        :raises ValidationError: when ``enrollment_id.currency_id`` is
+        :raises ValidationError: when ``_get_source_currency()`` is
             set and differs from ``company_currency_id``.
         """
         for record in self:
-            if (
-                record.enrollment_id
-                and record.enrollment_id.currency_id
-                and record.company_currency_id != record.enrollment_id.currency_id
-            ):
+            source_currency = record._get_source_currency()
+            if source_currency and record.company_currency_id != source_currency:
                 error_message = """
 Document Type: %s
 Context: Set award enrollment
@@ -731,7 +810,7 @@ Solution: Select an Enrollment billed in the award's Company Currency
                     self._description,
                     record.id,
                     record.company_currency_id.name,
-                    record.enrollment_id.currency_id.name,
+                    source_currency.name,
                 )
                 raise ValidationError(_(error_message))
 
@@ -873,9 +952,9 @@ Solution: Check generate schedule policy prerequisite
     def _generate_fee_reduction_schedule(self, benefit):
         """Create Schedule lines for a Fee Reduction line's periods.
 
-        One Schedule line is created per Payment Term of this
-        award's Enrollment whose Estimated Invoice Date falls within
-        ``date_start``..``date_end``.
+        One Schedule line is created per payment term of this
+        award's billing source whose Estimated Invoice Date falls
+        within ``date_start``..``date_end``.
 
         :param benefit: the ``school_scholarship_award_benefit``
             record being scheduled
@@ -884,16 +963,13 @@ Solution: Check generate schedule policy prerequisite
         """
         self.ensure_one()
         schedule_obj = self.env["school_scholarship_award_schedule"]
-        terms = self.enrollment_id.payment_term_ids.filtered(
+        terms = self._get_source_payment_terms().filtered(
             lambda term: term.date_invoice
             and self.date_start <= term.date_invoice <= self.date_end
         )
         for term in terms:
             existing = schedule_obj.search(
-                [
-                    ("benefit_id", "=", benefit.id),
-                    ("payment_term_id", "=", term.id),
-                ],
+                self._get_schedule_term_domain(benefit, term),
                 limit=1,
             )
             if existing:
@@ -966,12 +1042,76 @@ Solution: Check generate schedule policy prerequisite
             values
         """
         self.ensure_one()
-        return {
+        result = {
             "benefit_id": benefit.id,
-            "payment_term_id": payment_term.id if payment_term else False,
-            "date": payment_term.date_invoice if payment_term else date,
+            "payment_term_id": False,
+            "date": date,
             "state": "scheduled",
         }
+        if payment_term:
+            result.update(self._prepare_schedule_term_data(payment_term))
+            result["date"] = payment_term.date_invoice
+        return result
+
+    def _get_source_record(self):
+        """Return the billing source record backing this award.
+
+        Extension point: a module registering another Billing Source
+        value overrides this together with ``source_type``'s
+        ``selection_add`` to point at that value's own source record
+        instead.
+
+        :return: recordset of the billing source (``school_enrollment``
+            in this module), possibly empty
+        """
+        self.ensure_one()
+        return self.enrollment_id
+
+    def _get_source_payment_terms(self):
+        """Return the payment terms of this award's billing source.
+
+        :return: ``school_enrollment_payment_term`` recordset,
+            possibly empty
+        """
+        self.ensure_one()
+        return self.enrollment_id.payment_term_ids
+
+    def _get_source_currency(self):
+        """Return the currency of this award's billing source.
+
+        :return: ``res.currency`` record, or an empty recordset when
+            no billing source is set
+        """
+        self.ensure_one()
+        return self.enrollment_id.currency_id
+
+    def _get_schedule_term_domain(self, benefit, term):
+        """Build the domain finding an existing Schedule line.
+
+        Used by ``_generate_fee_reduction_schedule`` to decide
+        whether a (Benefit, term) pairing already has a Schedule
+        line, so generation stays idempotent.
+
+        :param benefit: the ``school_scholarship_award_benefit``
+            record being scheduled
+        :param term: the payment term record being realized
+        :return: a search domain list
+        """
+        self.ensure_one()
+        return [
+            ("benefit_id", "=", benefit.id),
+            ("payment_term_id", "=", term.id),
+        ]
+
+    def _prepare_schedule_term_data(self, payment_term):
+        """Build the payment-term-specific Schedule line values.
+
+        :param payment_term: the payment term record being realized
+        :return: dict of ``school_scholarship_award_schedule``
+            values
+        """
+        self.ensure_one()
+        return {"payment_term_id": payment_term.id}
 
     @api.model
     def _get_policy_field(self):

--- a/ssi_school_scholarship/models/school_scholarship_award_schedule.py
+++ b/ssi_school_scholarship/models/school_scholarship_award_schedule.py
@@ -126,7 +126,14 @@ class SchoolScholarshipAwardSchedule(models.Model):
     )
     payment_term_state = fields.Selection(
         string="Payment Term State",
-        related="payment_term_id.state",
+        selection=[
+            ("draft", "Draft"),
+            ("uninvoiced", "Uninvoiced"),
+            ("invoiced", "Invoiced"),
+            ("manual", "Manually Controlled"),
+            ("cancelled", "Cancelled"),
+        ],
+        compute="_compute_payment_term_state",
         store=True,
         compute_sudo=True,
         help="Billing status of the linked Payment Term.",
@@ -134,7 +141,7 @@ class SchoolScholarshipAwardSchedule(models.Model):
     customer_invoice_id = fields.Many2one(
         string="# Customer Invoice",
         comodel_name="customer_invoice",
-        related="payment_term_id.customer_invoice_id",
+        compute="_compute_customer_invoice_id",
         store=True,
         compute_sudo=True,
         help="Customer invoice of the linked Payment Term, once one "
@@ -155,21 +162,49 @@ class SchoolScholarshipAwardSchedule(models.Model):
         help="Free-form note about this schedule line.",
     )
 
+    def _get_source_term(self):
+        """Return the payment term this schedule line realizes.
+
+        Extension point: a module that gives Schedule its own extra
+        source field (alongside ``payment_term_id``) overrides this
+        to return that field instead.
+
+        :return: ``school_enrollment_payment_term`` record, or an
+            empty recordset when unset
+        """
+        self.ensure_one()
+        return self.payment_term_id
+
+    def _get_source_term_parent(self):
+        """Return the billing source record owning the source term.
+
+        Used by ``_check_payment_term_enrollment`` to compare against
+        the award's own ``_get_source_record()``, so that check stays
+        meaningful for whatever billing source an extension module
+        introduces.
+
+        :return: recordset of the source term's parent (e.g. its
+            ``school_enrollment``), possibly empty
+        """
+        self.ensure_one()
+        return self.payment_term_id.enrollment_id
+
     @api.depends("payment_term_id", "payment_term_id.name", "date")
     def _compute_name(self):
-        """Derive a display name from the Payment Term, or the Date.
+        """Derive a display name from the source term, or the Date.
 
         ``date`` is required, so on any persisted record it is
         already set by the time this runs -- there is no reachable
-        state with neither a Payment Term nor a Date, so the Date
+        state with neither a source term nor a Date, so the Date
         fallback needs no ``elif`` guard of its own.
 
         :return: nothing; assigns ``name``
         """
         for record in self:
             result = fields.Date.to_string(record.date)
-            if record.payment_term_id:
-                result = record.payment_term_id.name
+            term = record._get_source_term()
+            if term:
+                result = term.name
             record.name = result
 
     @api.depends(
@@ -181,7 +216,7 @@ class SchoolScholarshipAwardSchedule(models.Model):
         "benefit_id.product_category_id",
     )
     def _compute_base_amount(self):
-        """Sum the Payment Term detail lines matching the Benefit's scope.
+        """Sum the source term's detail lines matching the Benefit's scope.
 
         Matches by ``product_id`` when the Benefit line has no
         Product Category (a single-Product benefit), or by the
@@ -192,7 +227,7 @@ class SchoolScholarshipAwardSchedule(models.Model):
         """
         for record in self:
             result = 0.0
-            term = record.payment_term_id
+            term = record._get_source_term()
             benefit = record.benefit_id
             if term:
                 if benefit.product_category_id:
@@ -206,6 +241,26 @@ class SchoolScholarshipAwardSchedule(models.Model):
                     )
                 result = sum(details.mapped("price_subtotal"))
             record.base_amount = result
+
+    @api.depends("payment_term_id", "payment_term_id.state")
+    def _compute_payment_term_state(self):
+        """Mirror the source term's billing status.
+
+        :return: nothing; assigns ``payment_term_state``
+        """
+        for record in self:
+            term = record._get_source_term()
+            record.payment_term_state = term.state if term else False
+
+    @api.depends("payment_term_id", "payment_term_id.customer_invoice_id")
+    def _compute_customer_invoice_id(self):
+        """Mirror the source term's linked customer invoice.
+
+        :return: nothing; assigns ``customer_invoice_id``
+        """
+        for record in self:
+            term = record._get_source_term()
+            record.customer_invoice_id = term.customer_invoice_id if term else False
 
     @api.depends(
         "base_amount",
@@ -264,13 +319,14 @@ class SchoolScholarshipAwardSchedule(models.Model):
             Term.
         """
         for record in self:
-            if not record.payment_term_id:
+            term = record._get_source_term()
+            if not term:
                 continue
             duplicate_count = self.search_count(
                 [
                     ("id", "!=", record.id),
                     ("benefit_id", "=", record.benefit_id.id),
-                    ("payment_term_id", "=", record.payment_term_id.id),
+                    ("payment_term_id", "=", term.id),
                 ]
             )
             if duplicate_count > 0:
@@ -283,7 +339,7 @@ Solution: Select a Payment Term not yet scheduled for this Benefit line
 """ % (
                     self._description,
                     record.id,
-                    record.payment_term_id.display_name,
+                    term.display_name,
                 )
                 raise ValidationError(_(error_message))
 
@@ -292,13 +348,13 @@ Solution: Select a Payment Term not yet scheduled for this Benefit line
         """Require Payment Term for Fee Reduction, forbid it for Cash.
 
         :raises ValidationError: when the Benefit line's
-            ``benefit_type`` is ``fee_reduction`` and
-            ``payment_term_id`` is empty, or is ``cash`` and
-            ``payment_term_id`` is set.
+            ``benefit_type`` is ``fee_reduction`` and the source term
+            is empty, or is ``cash`` and the source term is set.
         """
         for record in self:
             benefit_type = record.benefit_id.benefit_type
-            if benefit_type == "fee_reduction" and not record.payment_term_id:
+            term = record._get_source_term()
+            if benefit_type == "fee_reduction" and not term:
                 error_message = """
 Document Type: %s
 Context: Configure award schedule
@@ -310,7 +366,7 @@ Solution: Select the Payment Term this schedule line realizes
                     record.id,
                 )
                 raise ValidationError(_(error_message))
-            if benefit_type == "cash" and record.payment_term_id:
+            if benefit_type == "cash" and term:
                 error_message = """
 Document Type: %s
 Context: Configure award schedule
@@ -325,18 +381,23 @@ Solution: Clear the Payment Term of this schedule line
 
     @api.constrains("payment_term_id", "award_id")
     def _check_payment_term_enrollment(self):
-        """Require the Payment Term to belong to the award's Enrollment.
+        """Require the source term to belong to the award's billing source.
 
-        :raises ValidationError: when ``payment_term_id.enrollment_id``
-            is set and differs from ``award_id.enrollment_id``.
+        Rewritten through ``_get_source_term``/``_get_source_term_parent``
+        and the award's own ``_get_source_record`` so this check keeps
+        working for whatever billing source an extension module adds,
+        without renaming this method or its XML ID references.
+
+        :raises ValidationError: when the source term's parent record
+            is set and differs from the award's own billing source
+            record.
         """
         for record in self:
-            term = record.payment_term_id
-            if (
-                term
-                and term.enrollment_id
-                and term.enrollment_id != record.award_id.enrollment_id
-            ):
+            term = record._get_source_term()
+            parent = record._get_source_term_parent()
+            award = record.award_id
+            source = award._get_source_record() if award else award
+            if term and parent and parent != source:
                 error_message = """
 Document Type: %s
 Context: Configure award schedule

--- a/ssi_school_scholarship/static/tests/tours/school_scholarship_award_tour.js
+++ b/ssi_school_scholarship/static/tests/tours/school_scholarship_award_tour.js
@@ -96,6 +96,17 @@ odoo.define("ssi_school_scholarship.school_scholarship_award_tour", function (re
                     ".ui-autocomplete .ui-menu-item a:contains(TOUR Award Student)",
                 in_modal: false,
             },
+            // Billing Source defaults to Enrollment and is left at
+            // that default -- only its visibility is asserted here,
+            // never its value (odoo-development-ui-test, tour tests
+            // the click-flow, not compute/onchange results).
+            {
+                content: "Billing Source field is displayed",
+                trigger: ".o_field_widget[name='source_type']",
+                run: function () {
+                    // Assertion only; do not trigger the default click.
+                },
+            },
             {
                 content: "Select the Enrollment",
                 trigger: ".o_field_many2one[name='enrollment_id'] input",

--- a/ssi_school_scholarship/tests/test_data_school_scholarship_award.yaml
+++ b/ssi_school_scholarship/tests/test_data_school_scholarship_award.yaml
@@ -194,6 +194,24 @@ scenarios:
             type: "value"
             expected: 0.0
 
+      # ── Positive (compute, default): source_type was not passed in
+      # values above -- it must default to "enrollment", and school_id
+      # /grade_id must be derived from the Enrollment through the
+      # _get_source_record() hook rather than left empty.
+      - step: "Assert Billing Source defaults to Enrollment, School/Grade derived"
+        action: "assert"
+        target: "award_zero"
+        asserts:
+          source_type:
+            type: "value"
+            expected: "enrollment"
+          school_id:
+            type: "m2o"
+            expected: "REC: school1"
+          grade_id:
+            type: "m2o"
+            expected: "REC: grade1"
+
       # ── Positive (compute, empty condition): two Benefit lines, but
       # Amount Awarded is derived from the Schedule now
       # (odoo-school-scholarship#6), not from the Benefit lines
@@ -936,6 +954,21 @@ scenarios:
                 benefit_type: "fee_reduction"
                 computation: "percentage"
                 percentage: 40.0
+
+      # ── Negative: Billing Source Enrollment with no Enrollment ────
+      - step: "Reject an Enrollment-sourced award with no Enrollment"
+        action: "create"
+        model: "school_scholarship_award"
+        expect_error:
+          type: "ValidationError"
+          message_contains: "billing source"
+        values:
+          program_id: "REC: program3.id"
+          student_id: "REC: student3a.id"
+          source_type: "enrollment"
+          date_start: 2026-07-01
+          date_end: 2026-12-31
+          discount_account_id: "REC: discount_account3.id"
 
       # ── Negative: Confirm without a Benefit line ─────────────────
       - step: "Create an award with Funding but no Benefit line"

--- a/ssi_school_scholarship/tests/test_data_school_scholarship_award_schedule.yaml
+++ b/ssi_school_scholarship/tests/test_data_school_scholarship_award_schedule.yaml
@@ -417,6 +417,17 @@ scenarios:
           amount_planned:
             type: "value"
             expected: 400000.0
+          # payment_term_state and customer_invoice_id switched from
+          # related to compute (odoo-school-scholarship#34) -- assert
+          # they still mirror the source term unchanged: the
+          # enrollment is still Draft (never confirmed in this
+          # scenario) and no invoice was ever created.
+          payment_term_state:
+            type: "value"
+            expected: "draft"
+          customer_invoice_id:
+            type: "value"
+            operator: "is_falsy"
 
       - step: "Manually override the July Schedule line's Amount Planned"
         action: "write"

--- a/ssi_school_scholarship/views/school_scholarship_award.xml
+++ b/ssi_school_scholarship/views/school_scholarship_award.xml
@@ -83,9 +83,11 @@
                 <field name="program_id" />
                 <field name="type_id" />
                 <field name="student_id" />
+                <field name="source_type" />
                 <field
                         name="enrollment_id"
                         domain="[('student_id', '=', student_id)]"
+                        attrs="{'required': [('source_type', '=', 'enrollment')], 'invisible': [('source_type', '!=', 'enrollment')]}"
                     />
                 <field name="school_id" />
                 <field name="grade_id" />


### PR DESCRIPTION
## Ringkasan

Menjadikan `school_scholarship_award` dan `school_scholarship_award_schedule` agnostik
terhadap sumber penagihan, sehingga modul lain (mis. Admission) dapat menambah sumber
penagihan baru tanpa menyentuh modul ini.

- Field diskriminator baru `source_type` ("Billing Source") pada Award, saat ini hanya
  mendaftarkan nilai `enrollment`.
- `enrollment_id` tidak lagi `required` di level field; kewajibannya dipindah ke
  constraint `_check_billing_source` + `attrs` di form view.
- Titik-ekstensi (hook) baru:
  - Award: `_get_source_record()`, `_get_source_payment_terms()`,
    `_get_source_currency()`, `_get_schedule_term_domain()`,
    `_prepare_schedule_term_data()`
  - Schedule: `_get_source_term()`, `_get_source_term_parent()`
- `school_id`/`grade_id` (Award) dan `payment_term_state`/`customer_invoice_id`
  (Schedule) dikonversi dari `related` menjadi `compute` tersimpan
  (`store=True`, `compute_sudo=True`) yang membaca lewat hook di atas — nilainya
  untuk data enrollment tetap identik seperti sebelumnya.
- Constraint lama (`_check_enrollment_student`, `_check_currency`,
  `_check_duplicate_benefit_payment_term`, `_check_payment_term_required`,
  `_check_payment_term_enrollment`) ditulis ulang lewat hook-hook di atas — nama
  method & XML ID lama dipertahankan seluruhnya.
- `migrations/14.0.1.6.0/post-migration.py` menegaskan `source_type='enrollment'`
  pada baris lama; `version` manifest dinaikkan manual ke `14.0.1.6.0` mengikuti
  skrip migrasi tersebut.
- IK `docs/school_scholarship_award/01-create.md` dan tour pasangannya diperbarui
  untuk memuat langkah Billing Source yang baru.

## Test plan

- [x] `assets/verify-module.sh` — `LOLOS: 0 ERROR`
- [x] `assets/validate-ik.sh` — `LOLOS: 0 ERROR` (1 peringatan warisan, tidak terkait)
- [x] `assets/validate-tour.sh` — `LOLOS: 0 ERROR`
- [x] `assets/validate-unit-test.sh` — 0 temuan baru dibanding HEAD (`vs-head.sh`)
- [x] Skenario uji baru: default `source_type` + turunan `school_id`/`grade_id`,
      penolakan award `source_type=enrollment` tanpa `enrollment_id`, regresi
      `payment_term_state`/`customer_invoice_id` pada Schedule
- [ ] CI hijau (menyusul)

Closes #34