### PR TITLE
[UPD] ssi_school_scholarship_deduction: deteksi schedule jatuh tempo sadar sumber penagihan

### DIFF
--- a/ssi_school_scholarship_deduction/models/school_scholarship_award.py
+++ b/ssi_school_scholarship_deduction/models/school_scholarship_award.py
@@ -99,13 +99,19 @@ Solution: Check create deduction policy prerequisite
     def _get_due_schedule(self, date_start=False, date_end=False):
         """Filter this Award's due, invoiced, unrealized Schedule lines.
 
-        A Schedule line is due once its own Payment Term has actually
-        been invoiced (``invoiced``) and that invoice is open
-        (``open``) -- together these two conditions make it
-        impossible for a Deduction to be created ahead of its own
-        invoice. A line already realized never matches (its own
-        ``state`` is no longer ``scheduled``), which is what makes
-        running this twice after the first Deduction opens idempotent.
+        A Schedule line is due once its own ``payment_term_state`` is
+        ``invoiced`` and its own linked ``customer_invoice_id`` is
+        open -- together these two conditions make it impossible for
+        a Deduction to be created ahead of its own invoice. Both
+        fields are stored, source-aware computes owned by
+        ``school_scholarship_award_schedule`` itself, so this filter
+        reads them directly instead of traversing into a billing
+        source's own Payment Term -- which is what lets an
+        admission-based Award's Schedule lines match here too,
+        without a source-specific branch. A line already realized
+        never matches (its own ``state`` is no longer ``scheduled``),
+        which is what makes running this twice after the first
+        Deduction opens idempotent.
 
         :param date_start: earliest Schedule Date to include, or
             ``False`` for no lower bound
@@ -117,8 +123,8 @@ Solution: Check create deduction policy prerequisite
         self.ensure_one()
         return self.schedule_ids.filtered(
             lambda schedule: schedule.state == "scheduled"
-            and schedule.payment_term_id.state == "invoiced"
-            and schedule.payment_term_id.customer_invoice_id.state == "open"
+            and schedule.payment_term_state == "invoiced"
+            and schedule.customer_invoice_id.state == "open"
             and (not date_start or schedule.date >= date_start)
             and (not date_end or schedule.date <= date_end)
         )

--- a/ssi_school_scholarship_deduction/tests/test_data_school_scholarship_award_create_due_deduction.yaml
+++ b/ssi_school_scholarship_deduction/tests/test_data_school_scholarship_award_create_due_deduction.yaml
@@ -1131,3 +1131,168 @@ scenarios:
         method: "action_open_create_due_deduction_wizard"
         expect_error:
           type: "UserError"
+
+      # ══════════════════════════════════════════════════════════════
+      # Sub-case F -- negative: a Schedule line whose own Payment Term
+      # is invoiced, but whose linked invoice was since cancelled (no
+      # longer Open), never matches _get_due_schedule -- the term's
+      # customer_invoice_id link survives a cancel, so this only
+      # exercises the invoice-state half of the filter, not the
+      # payment_term_state half already covered by Sub-case A/D.
+      # ══════════════════════════════════════════════════════════════
+      - step: "F: create the Payment Term"
+        action: "create"
+        model: "school_enrollment_payment_term"
+        save_as: "cdd_f_term"
+        values:
+          enrollment_id: "REC: cdd_enrollment.id"
+          name: "CDD F Term"
+          date_invoice: 2026-08-01
+          detail_ids:
+            - - 0
+              - 0
+              - product_id: "REC: cdd_product.id"
+                name: "CDD F Term Fee"
+                account_id: "REC: cdd_income_account.id"
+                uom_quantity: 1.0
+                uom_id: "REF: uom.product_uom_unit"
+                price_unit: 1000000.0
+
+      - step: "F: create the invoice"
+        action: "create"
+        model: "customer_invoice"
+        save_as: "cdd_f_invoice"
+        values:
+          name: "CDD-F-INV-001"
+          type_id: "REC: cdd_invoice_type.id"
+          partner_id: "REC: cdd_contact.id"
+          date: 2026-08-01
+          date_due: 2026-08-15
+          currency_id: "REC: company.currency_id.id"
+          journal_id: "REC: cdd_journal.id"
+          receivable_account_id: "REC: cdd_receivable_account.id"
+          user_id: "REF: base.user_admin"
+
+      - step: "Add a Line to CDD F Invoice (needed to stop at Open, not Done)"
+        action: "create"
+        model: "customer_invoice.line"
+        save_as: "cdd_f_invoice_line"
+        values:
+          customer_invoice_id: "REC: cdd_f_invoice.id"
+          name: "CDD F Invoice Line"
+          account_id: "REC: cdd_income_account.id"
+          uom_quantity: 1.0
+          price_unit: 1000000.0
+
+      - step: "F: confirm the invoice"
+        action: "call"
+        target: "cdd_f_invoice"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+        refresh: true
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
+
+      - step: "F: approve the invoice (opens it)"
+        action: "call"
+        target: "cdd_f_invoice"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        refresh: true
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+      - step: "F: link the invoice to the term"
+        action: "write"
+        target: "cdd_f_term"
+        values:
+          customer_invoice_id: "REC: cdd_f_invoice.id"
+
+      - step: "F: assert the term is now invoiced"
+        action: "assert"
+        target: "cdd_f_term"
+        asserts:
+          state:
+            type: "value"
+            expected: "invoiced"
+
+      - step: "F: cancel the invoice (no longer Open)"
+        action: "call"
+        target: "cdd_f_invoice"
+        method: "action_cancel"
+        as_user: "base.user_admin"
+        refresh: true
+        asserts:
+          state:
+            type: "value"
+            expected: "cancel"
+
+      - step: "F: create the award"
+        action: "create"
+        model: "school_scholarship_award"
+        save_as: "cdd_f_award"
+        values:
+          name: "CDD-F-AWARD-001"
+          program_id: "REC: cdd_program.id"
+          student_id: "REC: cdd_student.id"
+          enrollment_id: "REC: cdd_enrollment.id"
+          date_start: 2026-07-01
+          date_end: 2026-12-31
+          discount_account_id: "REC: cdd_discount_account.id"
+          deduction_journal_id: "REC: cdd_journal.id"
+          user_id: "REF: base.user_admin"
+          benefit_ids:
+            - - 0
+              - 0
+              - name: "CDD F Benefit"
+                product_id: "REC: cdd_product.id"
+                percentage: 100.0
+          funding_ids:
+            - - 0
+              - 0
+              - funding_source_id: "REC: cdd_funding_source_a.id"
+                percentage: 100.0
+
+      - step: "F: find the award's Benefit line"
+        action: "search"
+        model: "school_scholarship_award_benefit"
+        domain: [["award_id", "=", "REC: cdd_f_award.id"]]
+        limit: 1
+        save_as: "cdd_f_benefit"
+
+      - step: "F: create the Schedule line (term invoiced, invoice now cancelled)"
+        action: "create"
+        model: "school_scholarship_award_schedule"
+        save_as: "cdd_f_schedule"
+        values:
+          benefit_id: "REC: cdd_f_benefit.id"
+          payment_term_id: "REC: cdd_f_term.id"
+          date: "REC: cdd_f_term.date_invoice"
+          state: "scheduled"
+
+      - step: "F: assert the Schedule line mirrors invoiced/cancelled"
+        action: "assert"
+        target: "cdd_f_schedule"
+        asserts:
+          payment_term_state:
+            type: "value"
+            expected: "invoiced"
+          customer_invoice_id:
+            type: "m2o"
+            expected: "REC: cdd_f_invoice"
+
+      - step: "F: run _create_due_deduction -- no Deduction is created"
+        action: "call"
+        target: "cdd_f_award"
+        method: "_create_due_deduction"
+
+      - step: "F: assert no Deduction was created for the award"
+        action: "search"
+        model: "school_scholarship_deduction"
+        domain: [["award_id", "=", "REC: cdd_f_award.id"]]
+        save_as: "cdd_f_deductions"
+        expect_count: 0


### PR DESCRIPTION
## Ringkasan

`_get_due_schedule` pada `school_scholarship_award` (modul `ssi_school_scholarship_deduction`)
kini menyaring Schedule line lewat `payment_term_state` dan `customer_invoice_id` milik
`school_scholarship_award_schedule` sendiri -- dua field tersimpan yang sudah sadar sumber
penagihan sejak #34 -- bukan lagi menembus `payment_term_id` yang khusus menunjuk
`school_enrollment_payment_term`. Dengan begitu, Schedule line berbasis admission (yang
`payment_term_id`-nya memang kosong) ikut lolos filter jatuh tempo tanpa cabang kondisi per
sumber, sehingga potongan beasiswa bisa terbentuk untuk invoice admission.

Semantik "due" tidak berubah: tetap menuntut term sudah `invoiced` **dan** invoice-nya masih
`open`.

## Perubahan

- `models/school_scholarship_award.py`: filter `_get_due_schedule` dibaca dari
  `schedule.payment_term_state`/`schedule.customer_invoice_id` (bukan menembus
  `schedule.payment_term_id.state`/`schedule.payment_term_id.customer_invoice_id.state`).
  Docstring method diperbarui agar tidak lagi menyebut Payment Term enrollment.
- `tests/test_data_school_scholarship_award_create_due_deduction.yaml`: tambah Sub-case F --
  Schedule line yang term-nya sudah `invoiced` tapi invoice-nya kemudian dibatalkan (tidak
  lagi `open`) tetap tidak ikut terealisasi.

## Kriteria Penerimaan

- [x] `_get_due_schedule` tidak lagi menyebut `payment_term_id` di seluruh badannya
- [x] Award enrollment tetap menghasilkan Deduction yang sama persis (diverifikasi lewat
      skenario Sub-case A/B yang sudah ada, tidak diubah)
- [x] Schedule line yang term-nya belum `invoiced`, atau invoice-nya belum `open`, tetap
      tidak pernah ikut terealisasi (Sub-case A/D untuk term uninvoiced; Sub-case F baru
      untuk invoice tidak lagi open)
- [x] Docstring `_get_due_schedule` mencerminkan perilaku barunya

## Verifikasi

```
#VALIDATOR name=module target=ssi_school_scholarship_deduction series=14.0 mode=vs-head error=0 warn=0 defer=0 inherited=1 status=OK
#VALIDATOR name=unit-test target=ssi_school_scholarship_deduction series=14.0 mode=vs-head error=0 warn=0 defer=0 inherited=12 status=OK
```

Closes #36