### PR TITLE
[UPD] Tambahkan form inline pada setiap field one2many di view form

### DIFF
--- a/ssi_school_scholarship/views/school_scholarship_award.xml
+++ b/ssi_school_scholarship/views/school_scholarship_award.xml
@@ -157,6 +157,43 @@
                                  save. -->
                             <field name="name" invisible="1" />
                         </tree>
+                        <form>
+                            <group col="2">
+                                <field
+                                        name="scope_id"
+                                        domain="[('program_id', '=', parent.program_id)]"
+                                    />
+                                <field name="benefit_type" />
+                                <field name="product_id" />
+                                <field name="product_category_id" />
+                                <field name="computation" />
+                                <field
+                                        name="percentage"
+                                        attrs="{'invisible': [('computation', '!=', 'percentage')]}"
+                                    />
+                                <field
+                                        name="amount_fixed"
+                                        attrs="{'invisible': [('computation', '!=', 'fixed')]}"
+                                    />
+                                <field name="max_amount_per_period" />
+                                <field name="periodicity" />
+                                <field name="uom_quantity" />
+                                <field name="price_unit" />
+                                <field name="price_subtotal" />
+                                <field name="account_id" />
+                                <field name="currency_id" invisible="1" />
+                                <!-- Description (name, from mixin.product_line)
+                                     is only ever auto-filled by
+                                     onchange_name() when Product is picked; it
+                                     is not user-facing here, but the field
+                                     still must be present in the view so the
+                                     web client tracks the onchange's result.
+                                     Omitting it drops the value client-side,
+                                     and the required-field check fails on
+                                     save. -->
+                                <field name="name" invisible="1" />
+                            </group>
+                        </form>
                     </field>
                 </page>
                 <page name="funding" string="Funding">
@@ -174,6 +211,23 @@
                             <field name="amount_realized" />
                             <field name="currency_id" invisible="1" />
                         </tree>
+                        <form>
+                            <group col="2">
+                                <field
+                                        name="allowed_funding_source_ids"
+                                        invisible="1"
+                                    />
+                                <field
+                                        name="funding_source_id"
+                                        domain="[('id', 'in', allowed_funding_source_ids)]"
+                                    />
+                                <field name="analytic_account_id" />
+                                <field name="percentage" />
+                                <field name="amount_committed" />
+                                <field name="amount_realized" />
+                                <field name="currency_id" invisible="1" />
+                            </group>
+                        </form>
                     </field>
                 </page>
                 <page name="schedule" string="Schedule">
@@ -192,6 +246,22 @@
                             <field name="note" />
                             <field name="currency_id" invisible="1" />
                         </tree>
+                        <form>
+                            <group col="2">
+                                <field name="benefit_id" />
+                                <field name="payment_term_id" />
+                                <field name="date" />
+                                <field name="base_amount" />
+                                <field name="amount_planned" />
+                                <field name="amount_planned_manual" invisible="1" />
+                                <field name="amount_realized" />
+                                <field name="state" />
+                                <field name="payment_term_state" />
+                                <field name="customer_invoice_id" />
+                                <field name="currency_id" invisible="1" />
+                            </group>
+                            <field name="note" />
+                        </form>
                     </field>
                 </page>
                 <page name="letter" string="Letters">
@@ -202,6 +272,14 @@
                             <field name="date_signed" />
                             <field name="signed_by" />
                         </tree>
+                        <form>
+                            <group col="2">
+                                <field name="date" />
+                                <field name="letter_type" />
+                                <field name="date_signed" />
+                                <field name="signed_by" />
+                            </group>
+                        </form>
                     </field>
                 </page>
                 <page name="compliance_renewal" string="Compliance &amp; Renewal">
@@ -216,6 +294,13 @@
                             <field name="date" />
                             <field name="state" />
                         </tree>
+                        <form>
+                            <group col="2">
+                                <field name="name" />
+                                <field name="date" />
+                                <field name="state" />
+                            </group>
+                        </form>
                     </field>
                 </page>
                 <page name="accounting" string="Accounting">

--- a/ssi_school_scholarship/views/school_scholarship_program.xml
+++ b/ssi_school_scholarship/views/school_scholarship_program.xml
@@ -115,6 +115,32 @@
                             <field name="periodicity" />
                             <field name="currency_id" invisible="1" />
                         </tree>
+                        <form>
+                            <group col="2">
+                                <field name="scope_basis" />
+                                <field
+                                        name="product_id"
+                                        attrs="{'invisible': [('scope_basis', '!=', 'product')], 'required': [('scope_basis', '=', 'product')]}"
+                                    />
+                                <field
+                                        name="product_category_id"
+                                        attrs="{'invisible': [('scope_basis', '!=', 'product_category')], 'required': [('scope_basis', '=', 'product_category')]}"
+                                    />
+                                <field name="benefit_type" />
+                                <field name="computation" />
+                                <field
+                                        name="percentage"
+                                        attrs="{'invisible': [('computation', '!=', 'percentage')]}"
+                                    />
+                                <field
+                                        name="amount_fixed"
+                                        attrs="{'invisible': [('computation', '!=', 'fixed')]}"
+                                    />
+                                <field name="max_amount_per_period" />
+                                <field name="periodicity" />
+                                <field name="currency_id" invisible="1" />
+                            </group>
+                        </form>
                     </field>
                 </page>
                 <page name="criteria" string="Criteria">
@@ -134,6 +160,22 @@
                             <field name="is_hard_requirement" />
                             <field name="weight" />
                         </tree>
+                        <form>
+                            <group col="2">
+                                <field name="name" />
+                                <field name="evaluation_method" />
+                                <field name="is_hard_requirement" />
+                                <field name="weight" />
+                            </group>
+                            <field
+                                    name="criteria_domain"
+                                    attrs="{'invisible': [('evaluation_method', '!=', 'domain')]}"
+                                />
+                            <field
+                                    name="python_code"
+                                    attrs="{'invisible': [('evaluation_method', '!=', 'python')]}"
+                                />
+                        </form>
                     </field>
                 </page>
                 <page name="deduction" string="Deduction">

--- a/ssi_school_scholarship_deduction/views/school_scholarship_deduction.xml
+++ b/ssi_school_scholarship_deduction/views/school_scholarship_deduction.xml
@@ -141,6 +141,15 @@
                             <field name="state" />
                             <field name="currency_id" invisible="1" />
                         </tree>
+                        <form>
+                            <group col="2">
+                                <field name="name" />
+                                <field name="date" />
+                                <field name="amount" widget="monetary" />
+                                <field name="state" />
+                                <field name="currency_id" invisible="1" />
+                            </group>
+                        </form>
                     </field>
                 </page>
                 <page name="line" string="Lines">
@@ -176,6 +185,38 @@
                                  check fails on save. -->
                             <field name="name" invisible="1" />
                         </tree>
+                        <form>
+                            <group col="2">
+                                <field
+                                        name="schedule_id"
+                                        domain="[('award_id', '=', parent.award_id)]"
+                                    />
+                                <field name="benefit_id" />
+                                <field
+                                        name="funding_id"
+                                        domain="[('award_id', '=', parent.award_id)]"
+                                    />
+                                <field name="funding_source_id" />
+                                <field name="product_id" />
+                                <field name="final_account_id" />
+                                <field name="account_id" />
+                                <field name="analytic_account_id" />
+                                <field name="uom_quantity" />
+                                <field name="price_unit" />
+                                <field name="price_subtotal" />
+                                <field name="currency_id" invisible="1" />
+                                <!-- Description (name, from mixin.product_line)
+                                     is only ever auto-filled by
+                                     onchange_name() when Schedule is picked;
+                                     it is not user-facing here, but the
+                                     field still must be present in the view
+                                     so the web client tracks the onchange's
+                                     result. Omitting it drops the value
+                                     client-side, and the required-field
+                                     check fails on save. -->
+                                <field name="name" invisible="1" />
+                            </group>
+                        </form>
                     </field>
                 </page>
                 <page name="allocation" string="Allocations">
@@ -188,6 +229,16 @@
                             <field name="partial_reconcile_id" />
                             <field name="currency_id" invisible="1" />
                         </tree>
+                        <form>
+                            <group col="2">
+                                <field name="customer_invoice_id" />
+                                <field name="invoice_residual" />
+                                <field name="invoice_account_id" />
+                                <field name="amount_allocated" />
+                                <field name="partial_reconcile_id" />
+                                <field name="currency_id" invisible="1" />
+                            </group>
+                        </form>
                     </field>
                 </page>
                 <page name="schedule" string="Realized Schedule">
@@ -198,6 +249,14 @@
                             <field name="amount_planned" />
                             <field name="state" />
                         </tree>
+                        <form>
+                            <group col="2">
+                                <field name="benefit_id" />
+                                <field name="date" />
+                                <field name="amount_planned" />
+                                <field name="state" />
+                            </group>
+                        </form>
                     </field>
                 </page>
             </xpath>

--- a/ssi_school_scholarship_deduction/views/school_scholarship_deduction_recognition.xml
+++ b/ssi_school_scholarship_deduction/views/school_scholarship_deduction_recognition.xml
@@ -80,6 +80,16 @@
                             <field name="amount" widget="monetary" />
                             <field name="company_currency_id" invisible="1" />
                         </tree>
+                        <form>
+                            <group col="2">
+                                <field name="deduction_line_id" />
+                                <field name="debit_account_id" />
+                                <field name="credit_account_id" />
+                                <field name="analytic_account_id" />
+                                <field name="amount" widget="monetary" />
+                                <field name="company_currency_id" invisible="1" />
+                            </group>
+                        </form>
                     </field>
                 </page>
                 <page name="note" string="Note">

--- a/ssi_school_scholarship_disbursement/views/school_scholarship_disbursement.xml
+++ b/ssi_school_scholarship_disbursement/views/school_scholarship_disbursement.xml
@@ -128,6 +128,38 @@
                                  check fails on save. -->
                             <field name="name" invisible="1" />
                         </tree>
+                        <form>
+                            <group col="2">
+                                <field
+                                        name="schedule_id"
+                                        domain="[('award_id', '=', parent.award_id)]"
+                                    />
+                                <field name="benefit_id" />
+                                <field
+                                        name="funding_id"
+                                        domain="[('award_id', '=', parent.award_id)]"
+                                    />
+                                <field name="funding_source_id" />
+                                <field name="product_id" />
+                                <field name="final_account_id" />
+                                <field name="account_id" />
+                                <field name="analytic_account_id" />
+                                <field name="uom_quantity" />
+                                <field name="price_unit" />
+                                <field name="price_subtotal" />
+                                <field name="currency_id" invisible="1" />
+                                <!-- Description (name, from mixin.product_line)
+                                     is only ever auto-filled by
+                                     onchange_name() when Schedule is picked;
+                                     it is not user-facing here, but the
+                                     field still must be present in the view
+                                     so the web client tracks the onchange's
+                                     result. Omitting it drops the value
+                                     client-side, and the required-field
+                                     check fails on save. -->
+                                <field name="name" invisible="1" />
+                            </group>
+                        </form>
                     </field>
                 </page>
                 <page name="payment" string="Payments">
@@ -138,6 +170,14 @@
                             <field name="partial_reconcile_id" />
                             <field name="currency_id" invisible="1" />
                         </tree>
+                        <form>
+                            <group col="2">
+                                <field name="payment_id" />
+                                <field name="amount" widget="monetary" />
+                                <field name="partial_reconcile_id" />
+                                <field name="currency_id" invisible="1" />
+                            </group>
+                        </form>
                     </field>
                 </page>
                 <page name="schedule" string="Realized Schedule">
@@ -148,6 +188,14 @@
                             <field name="amount_planned" />
                             <field name="state" />
                         </tree>
+                        <form>
+                            <group col="2">
+                                <field name="benefit_id" />
+                                <field name="date" />
+                                <field name="amount_planned" />
+                                <field name="state" />
+                            </group>
+                        </form>
                     </field>
                 </page>
             </xpath>


### PR DESCRIPTION
## Ringkasan

Menambahkan `<form>` inline sebagai sibling `<tree>` pada setiap field one2many yang dirender di view form, di tiga modul: `ssi_school_scholarship`, `ssi_school_scholarship_deduction`, `ssi_school_scholarship_disbursement`.

Di Odoo 14, atribut `editable` pada tree x2many hanya berlaku saat form induk berada di mode edit. Saat mode lihat (readonly), klik baris tree meneruskan ke `_openFormDialog()`, dan tanpa `<form>` inline, client menarik form default comodel — untuk comodel tanpa form (mis. `school_scholarship_award_benefit`) tampil form auto-generate seluruh field; untuk comodel dokumen penuh (mis. `school_scholarship_award` pada `renewal_award_ids`) tampil statusbar/policy/chatter yang tidak relevan.

## Perubahan

- `ssi_school_scholarship`: form inline untuk `benefit_ids`, `funding_ids`, `schedule_ids`, `letter_ids`, `renewal_award_ids` (form Award) serta `scope_ids`, `criteria_ids` (form Program).
- `ssi_school_scholarship_deduction`: form inline untuk `recognition_ids`, `line_ids`, `allocation_ids`, `schedule_ids` (form Deduction) serta `recognition_line_ids` (form Deduction Recognition).
- `ssi_school_scholarship_disbursement`: form inline untuk `line_ids`, `payment_ids`, `schedule_ids`.

Total 15 field o2m. Isi form inline = kolom tree apa adanya (domain/attrs disalin, termasuk yang memakai `parent.`), dibungkus satu `<group col="2">`. Field teknis invisible di tree tetap invisible di form. Field teks panjang (`note`, `criteria_domain`, `python_code`) diletakkan lebar penuh di luar `<group>`. `sequence` tidak dimasukkan ke form inline. `renewal_award_ids`, `recognition_ids`, dan `schedule_ids` tab "Realized Schedule" (comodel dokumen penuh) hanya memuat kolom ringkas dari tree, tanpa statusbar/policy/chatter.

**Catatan penyimpangan kecil dari draft Keputusan Desain:** issue menyebut field teks panjang `note` berlaku untuk `schedule_ids` **dan** `letter_ids`. Pada `letter_ids` (tab Letters, form Award), tree yang ada saat ini **tidak** memuat kolom `note` sama sekali (hanya `date`, `letter_type`, `date_signed`, `signed_by`) — field `note` di model `school_scholarship_letter` memang ada tapi tidak pernah dirender di tree manapun. Mengikuti prinsip utama Keputusan Desain ("Isi form inline = kolom tree-nya... tidak menambah field di luar tree") dan Kriteria Penerimaan ("tak ada kolom `<tree>` yang berubah"), form inline `letter_ids` di PR ini **tidak** menyertakan `note` — hanya mengikuti 4 kolom yang benar-benar ada di tree-nya.

Tak ada perubahan model/security/manifest; `version` tidak dinaikkan manual.

Closes #38