### PR TITLE
[UPD] Pisahkan kategori group workflow & data ownership per model

### DIFF
--- a/ssi_school_scholarship/__manifest__.py
+++ b/ssi_school_scholarship/__manifest__.py
@@ -30,6 +30,7 @@
     ],
     "data": [
         "security/ir_module_category_data.xml",
+        "security/ir_module_category/school_scholarship_award.xml",
         "security/res_groups/school_scholarship_type.xml",
         "security/res_groups/school_scholarship_funding_source.xml",
         "security/res_groups/school_scholarship_program.xml",

--- a/ssi_school_scholarship/security/ir_module_category/school_scholarship_award.xml
+++ b/ssi_school_scholarship/security/ir_module_category/school_scholarship_award.xml
@@ -16,9 +16,6 @@
         model="ir.module.category"
     >
     <field name="name">Scholarship Award</field>
-    <field
-            name="parent_id"
-            ref="school_scholarship_data_ownership_module_category"
-        />
+    <field name="parent_id" ref="school_scholarship_data_ownership_module_category" />
 </record>
 </odoo>

--- a/ssi_school_scholarship/security/ir_module_category/school_scholarship_award.xml
+++ b/ssi_school_scholarship/security/ir_module_category/school_scholarship_award.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+<record
+        id="school_scholarship_award_workflow_module_category"
+        model="ir.module.category"
+    >
+    <field name="name">Scholarship Award</field>
+    <field name="parent_id" ref="school_scholarship_workflow_module_category" />
+</record>
+
+<record
+        id="school_scholarship_award_data_ownership_module_category"
+        model="ir.module.category"
+    >
+    <field name="name">Scholarship Award</field>
+    <field
+            name="parent_id"
+            ref="school_scholarship_data_ownership_module_category"
+        />
+</record>
+</odoo>

--- a/ssi_school_scholarship/security/res_groups/school_scholarship_award.xml
+++ b/ssi_school_scholarship/security/res_groups/school_scholarship_award.xml
@@ -6,18 +6,12 @@
 <!-- Workflow -->
 <record id="school_scholarship_award_viewer_group" model="res.groups">
     <field name="name">Viewer</field>
-    <field
-            name="category_id"
-            ref="school_scholarship_award_workflow_module_category"
-        />
+    <field name="category_id" ref="school_scholarship_award_workflow_module_category" />
 </record>
 
 <record id="school_scholarship_award_user_group" model="res.groups">
     <field name="name">User</field>
-    <field
-            name="category_id"
-            ref="school_scholarship_award_workflow_module_category"
-        />
+    <field name="category_id" ref="school_scholarship_award_workflow_module_category" />
     <field
             name="implied_ids"
             eval="[(4, ref('school_scholarship_award_viewer_group'))]"
@@ -26,10 +20,7 @@
 
 <record id="school_scholarship_award_validator_group" model="res.groups">
     <field name="name">Validator</field>
-    <field
-            name="category_id"
-            ref="school_scholarship_award_workflow_module_category"
-        />
+    <field name="category_id" ref="school_scholarship_award_workflow_module_category" />
     <field
             name="implied_ids"
             eval="[(4, ref('school_scholarship_award_user_group'))]"

--- a/ssi_school_scholarship/security/res_groups/school_scholarship_award.xml
+++ b/ssi_school_scholarship/security/res_groups/school_scholarship_award.xml
@@ -5,13 +5,19 @@
 <odoo>
 <!-- Workflow -->
 <record id="school_scholarship_award_viewer_group" model="res.groups">
-    <field name="name">Award Viewer</field>
-    <field name="category_id" ref="school_scholarship_workflow_module_category" />
+    <field name="name">Viewer</field>
+    <field
+            name="category_id"
+            ref="school_scholarship_award_workflow_module_category"
+        />
 </record>
 
 <record id="school_scholarship_award_user_group" model="res.groups">
-    <field name="name">Award User</field>
-    <field name="category_id" ref="school_scholarship_workflow_module_category" />
+    <field name="name">User</field>
+    <field
+            name="category_id"
+            ref="school_scholarship_award_workflow_module_category"
+        />
     <field
             name="implied_ids"
             eval="[(4, ref('school_scholarship_award_viewer_group'))]"
@@ -19,8 +25,11 @@
 </record>
 
 <record id="school_scholarship_award_validator_group" model="res.groups">
-    <field name="name">Award Validator</field>
-    <field name="category_id" ref="school_scholarship_workflow_module_category" />
+    <field name="name">Validator</field>
+    <field
+            name="category_id"
+            ref="school_scholarship_award_workflow_module_category"
+        />
     <field
             name="implied_ids"
             eval="[(4, ref('school_scholarship_award_user_group'))]"
@@ -33,13 +42,19 @@
 
 <!-- Data Ownership -->
 <record id="school_scholarship_award_company_group" model="res.groups">
-    <field name="name">Award Company</field>
-    <field name="category_id" ref="school_scholarship_data_ownership_module_category" />
+    <field name="name">Company</field>
+    <field
+            name="category_id"
+            ref="school_scholarship_award_data_ownership_module_category"
+        />
 </record>
 
 <record id="school_scholarship_award_company_child_group" model="res.groups">
-    <field name="name">Award Company and All Child Companies</field>
-    <field name="category_id" ref="school_scholarship_data_ownership_module_category" />
+    <field name="name">Company and All Child Companies</field>
+    <field
+            name="category_id"
+            ref="school_scholarship_award_data_ownership_module_category"
+        />
     <field
             name="implied_ids"
             eval="[(4, ref('school_scholarship_award_company_group'))]"
@@ -47,8 +62,11 @@
 </record>
 
 <record id="school_scholarship_award_all_group" model="res.groups">
-    <field name="name">Award All</field>
-    <field name="category_id" ref="school_scholarship_data_ownership_module_category" />
+    <field name="name">All</field>
+    <field
+            name="category_id"
+            ref="school_scholarship_award_data_ownership_module_category"
+        />
     <field
             name="implied_ids"
             eval="[(4, ref('school_scholarship_award_company_child_group'))]"

--- a/ssi_school_scholarship/tests/__init__.py
+++ b/ssi_school_scholarship/tests/__init__.py
@@ -15,3 +15,4 @@ from . import test_school_scholarship_award_schedule
 from . import test_ui_school_scholarship_award
 from . import test_school_student
 from . import test_school_enrollment
+from . import test_module_category

--- a/ssi_school_scholarship/tests/test_data_module_category.yaml
+++ b/ssi_school_scholarship/tests/test_data_module_category.yaml
@@ -86,8 +86,8 @@ scenarios:
             type: "value"
             expected: "All"
 
-  - name: "New award categories are parented under the shared School Scholarship
-      categories"
+  - name:
+      "New award categories are parented under the shared School Scholarship categories"
     steps:
       - step: "Get school_scholarship_award_workflow_module_category by XML ID"
         action: "ref"
@@ -169,7 +169,8 @@ scenarios:
             [
               "category_id",
               "=",
-              "REF: ssi_school_scholarship.school_scholarship_data_ownership_module_category",
+              "REF:
+              ssi_school_scholarship.school_scholarship_data_ownership_module_category",
             ],
           ]
         save_as: "orphan_data_ownership_groups"

--- a/ssi_school_scholarship/tests/test_data_module_category.yaml
+++ b/ssi_school_scholarship/tests/test_data_module_category.yaml
@@ -159,9 +159,19 @@ scenarios:
         save_as: "orphan_workflow_groups"
         expect_count: 0
 
-  - name: "No res.groups still points at the shared data ownership category"
+  - name:
+      "Only the out-of-scope Deduction Recognition group still points at the shared data
+      ownership category"
     steps:
-      - step: "Search res.groups on the shared data ownership category"
+      - step:
+          "Get the deliberately out-of-scope Deduction Recognition Operating Unit
+          group's id"
+        action: "ref"
+        xml_id: "ssi_school_scholarship_deduction_operating_unit.school_scholarship_deduction_recognition_operating_unit_group"
+        save_as: "recognition_ou_group"
+      - step:
+          "Search res.groups on the shared data ownership category, excluding the
+          deliberately out-of-scope Recognition group"
         action: "search"
         model: "res.groups"
         domain:
@@ -172,6 +182,7 @@ scenarios:
               "REF:
               ssi_school_scholarship.school_scholarship_data_ownership_module_category",
             ],
+            ["id", "!=", "REC: recognition_ou_group.id"],
           ]
         save_as: "orphan_data_ownership_groups"
         expect_count: 0

--- a/ssi_school_scholarship/tests/test_data_module_category.yaml
+++ b/ssi_school_scholarship/tests/test_data_module_category.yaml
@@ -1,0 +1,176 @@
+scenarios:
+  - name: "Award workflow/data ownership groups point to their own model category"
+    steps:
+      - step: "Get school_scholarship_award_viewer_group by XML ID"
+        action: "ref"
+        xml_id: "ssi_school_scholarship.school_scholarship_award_viewer_group"
+        save_as: "award_viewer_group"
+      - step: "Get school_scholarship_award_user_group by XML ID"
+        action: "ref"
+        xml_id: "ssi_school_scholarship.school_scholarship_award_user_group"
+        save_as: "award_user_group"
+      - step: "Get school_scholarship_award_validator_group by XML ID"
+        action: "ref"
+        xml_id: "ssi_school_scholarship.school_scholarship_award_validator_group"
+        save_as: "award_validator_group"
+      - step: "Get school_scholarship_award_company_group by XML ID"
+        action: "ref"
+        xml_id: "ssi_school_scholarship.school_scholarship_award_company_group"
+        save_as: "award_company_group"
+      - step: "Get school_scholarship_award_company_child_group by XML ID"
+        action: "ref"
+        xml_id: "ssi_school_scholarship.school_scholarship_award_company_child_group"
+        save_as: "award_company_child_group"
+      - step: "Get school_scholarship_award_all_group by XML ID"
+        action: "ref"
+        xml_id: "ssi_school_scholarship.school_scholarship_award_all_group"
+        save_as: "award_all_group"
+      - step: "Assert award_viewer_group category_id and literal name"
+        action: "assert"
+        target: "award_viewer_group"
+        asserts:
+          category_id:
+            type: "m2o"
+            expected_xml_id: "ssi_school_scholarship.school_scholarship_award_workflow_module_category"
+          name:
+            type: "value"
+            expected: "Viewer"
+      - step: "Assert award_user_group category_id and literal name"
+        action: "assert"
+        target: "award_user_group"
+        asserts:
+          category_id:
+            type: "m2o"
+            expected_xml_id: "ssi_school_scholarship.school_scholarship_award_workflow_module_category"
+          name:
+            type: "value"
+            expected: "User"
+      - step: "Assert award_validator_group category_id and literal name"
+        action: "assert"
+        target: "award_validator_group"
+        asserts:
+          category_id:
+            type: "m2o"
+            expected_xml_id: "ssi_school_scholarship.school_scholarship_award_workflow_module_category"
+          name:
+            type: "value"
+            expected: "Validator"
+      - step: "Assert award_company_group category_id and literal name"
+        action: "assert"
+        target: "award_company_group"
+        asserts:
+          category_id:
+            type: "m2o"
+            expected_xml_id: "ssi_school_scholarship.school_scholarship_award_data_ownership_module_category"
+          name:
+            type: "value"
+            expected: "Company"
+      - step: "Assert award_company_child_group category_id and literal name"
+        action: "assert"
+        target: "award_company_child_group"
+        asserts:
+          category_id:
+            type: "m2o"
+            expected_xml_id: "ssi_school_scholarship.school_scholarship_award_data_ownership_module_category"
+          name:
+            type: "value"
+            expected: "Company and All Child Companies"
+      - step: "Assert award_all_group category_id and literal name"
+        action: "assert"
+        target: "award_all_group"
+        asserts:
+          category_id:
+            type: "m2o"
+            expected_xml_id: "ssi_school_scholarship.school_scholarship_award_data_ownership_module_category"
+          name:
+            type: "value"
+            expected: "All"
+
+  - name: "New award categories are parented under the shared School Scholarship
+      categories"
+    steps:
+      - step: "Get school_scholarship_award_workflow_module_category by XML ID"
+        action: "ref"
+        xml_id: "ssi_school_scholarship.school_scholarship_award_workflow_module_category"
+        save_as: "award_workflow_category"
+      - step: "Get school_scholarship_award_data_ownership_module_category by XML ID"
+        action: "ref"
+        xml_id: "ssi_school_scholarship.school_scholarship_award_data_ownership_module_category"
+        save_as: "award_data_ownership_category"
+      - step: "Assert award_workflow_category parent_id and name"
+        action: "assert"
+        target: "award_workflow_category"
+        asserts:
+          parent_id:
+            type: "m2o"
+            expected_xml_id: "ssi_school_scholarship.school_scholarship_workflow_module_category"
+          name:
+            type: "value"
+            expected: "Scholarship Award"
+      - step: "Assert award_data_ownership_category parent_id and name"
+        action: "assert"
+        target: "award_data_ownership_category"
+        asserts:
+          parent_id:
+            type: "m2o"
+            expected_xml_id: "ssi_school_scholarship.school_scholarship_data_ownership_module_category"
+          name:
+            type: "value"
+            expected: "Scholarship Award"
+
+  - name: "Old shared workflow/data ownership categories still exist as parents"
+    steps:
+      - step: "Get the old shared workflow category by XML ID"
+        action: "ref"
+        xml_id: "ssi_school_scholarship.school_scholarship_workflow_module_category"
+        save_as: "shared_workflow_category"
+      - step: "Get the old shared data ownership category by XML ID"
+        action: "ref"
+        xml_id: "ssi_school_scholarship.school_scholarship_data_ownership_module_category"
+        save_as: "shared_data_ownership_category"
+      - step: "Assert the shared categories are still named as before"
+        action: "assert"
+        target: "shared_workflow_category"
+        asserts:
+          name:
+            type: "value"
+            expected: "School - Scholarship - Workflow"
+      - step: "Assert the shared data ownership category is still named as before"
+        action: "assert"
+        target: "shared_data_ownership_category"
+        asserts:
+          name:
+            type: "value"
+            expected: "School - Scholarship - Data Ownership"
+
+  - name: "No res.groups still points at the shared workflow category"
+    steps:
+      - step: "Search res.groups on the shared workflow category"
+        action: "search"
+        model: "res.groups"
+        domain:
+          [
+            [
+              "category_id",
+              "=",
+              "REF: ssi_school_scholarship.school_scholarship_workflow_module_category",
+            ],
+          ]
+        save_as: "orphan_workflow_groups"
+        expect_count: 0
+
+  - name: "No res.groups still points at the shared data ownership category"
+    steps:
+      - step: "Search res.groups on the shared data ownership category"
+        action: "search"
+        model: "res.groups"
+        domain:
+          [
+            [
+              "category_id",
+              "=",
+              "REF: ssi_school_scholarship.school_scholarship_data_ownership_module_category",
+            ],
+          ]
+        save_as: "orphan_data_ownership_groups"
+        expect_count: 0

--- a/ssi_school_scholarship/tests/test_module_category.py
+++ b/ssi_school_scholarship/tests/test_module_category.py
@@ -1,0 +1,19 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestModuleCategory(YamlTransactionCase):
+    """Scenario tests for the ``school_scholarship_award`` module
+    categories, run against the security data declared in
+    ``security/ir_module_category/`` and ``security/res_groups/``.
+    """
+
+    def test_module_category(self):
+        """Run the award category/group repointing scenarios."""
+        self.run_yaml_scenario("test_data_module_category.yaml")

--- a/ssi_school_scholarship_deduction/__manifest__.py
+++ b/ssi_school_scholarship_deduction/__manifest__.py
@@ -23,6 +23,7 @@
         "web_tour",
     ],
     "data": [
+        "security/ir_module_category/school_scholarship_deduction.xml",
         "security/res_groups/school_scholarship_deduction.xml",
         "security/ir_model_access/school_scholarship_deduction.xml",
         "security/ir_model_access/school_scholarship_deduction_line.xml",

--- a/ssi_school_scholarship_deduction/security/ir_module_category/school_scholarship_deduction.xml
+++ b/ssi_school_scholarship_deduction/security/ir_module_category/school_scholarship_deduction.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+<record
+        id="school_scholarship_deduction_workflow_module_category"
+        model="ir.module.category"
+    >
+    <field name="name">Scholarship Deduction</field>
+    <field
+            name="parent_id"
+            ref="ssi_school_scholarship.school_scholarship_workflow_module_category"
+        />
+</record>
+
+<record
+        id="school_scholarship_deduction_data_ownership_module_category"
+        model="ir.module.category"
+    >
+    <field name="name">Scholarship Deduction</field>
+    <field
+            name="parent_id"
+            ref="ssi_school_scholarship.school_scholarship_data_ownership_module_category"
+        />
+</record>
+</odoo>

--- a/ssi_school_scholarship_deduction/security/res_groups/school_scholarship_deduction.xml
+++ b/ssi_school_scholarship_deduction/security/res_groups/school_scholarship_deduction.xml
@@ -5,18 +5,18 @@
 <odoo>
 <!-- Workflow -->
 <record id="school_scholarship_deduction_viewer_group" model="res.groups">
-    <field name="name">Deduction Viewer</field>
+    <field name="name">Viewer</field>
     <field
             name="category_id"
-            ref="ssi_school_scholarship.school_scholarship_workflow_module_category"
+            ref="school_scholarship_deduction_workflow_module_category"
         />
 </record>
 
 <record id="school_scholarship_deduction_user_group" model="res.groups">
-    <field name="name">Deduction User</field>
+    <field name="name">User</field>
     <field
             name="category_id"
-            ref="ssi_school_scholarship.school_scholarship_workflow_module_category"
+            ref="school_scholarship_deduction_workflow_module_category"
         />
     <field
             name="implied_ids"
@@ -25,10 +25,10 @@
 </record>
 
 <record id="school_scholarship_deduction_validator_group" model="res.groups">
-    <field name="name">Deduction Validator</field>
+    <field name="name">Validator</field>
     <field
             name="category_id"
-            ref="ssi_school_scholarship.school_scholarship_workflow_module_category"
+            ref="school_scholarship_deduction_workflow_module_category"
         />
     <field
             name="implied_ids"
@@ -42,18 +42,18 @@
 
 <!-- Data Ownership -->
 <record id="school_scholarship_deduction_company_group" model="res.groups">
-    <field name="name">Deduction Company</field>
+    <field name="name">Company</field>
     <field
             name="category_id"
-            ref="ssi_school_scholarship.school_scholarship_data_ownership_module_category"
+            ref="school_scholarship_deduction_data_ownership_module_category"
         />
 </record>
 
 <record id="school_scholarship_deduction_company_child_group" model="res.groups">
-    <field name="name">Deduction Company and All Child Companies</field>
+    <field name="name">Company and All Child Companies</field>
     <field
             name="category_id"
-            ref="ssi_school_scholarship.school_scholarship_data_ownership_module_category"
+            ref="school_scholarship_deduction_data_ownership_module_category"
         />
     <field
             name="implied_ids"
@@ -62,10 +62,10 @@
 </record>
 
 <record id="school_scholarship_deduction_all_group" model="res.groups">
-    <field name="name">Deduction All</field>
+    <field name="name">All</field>
     <field
             name="category_id"
-            ref="ssi_school_scholarship.school_scholarship_data_ownership_module_category"
+            ref="school_scholarship_deduction_data_ownership_module_category"
         />
     <field
             name="implied_ids"

--- a/ssi_school_scholarship_deduction/tests/__init__.py
+++ b/ssi_school_scholarship_deduction/tests/__init__.py
@@ -9,3 +9,4 @@ from . import test_ui_school_scholarship_award_create_due_deduction  # noqa: F40
 from . import test_school_scholarship_deduction_recognition  # noqa: F401
 from . import test_ui_school_scholarship_deduction_recognition  # noqa: F401
 from . import test_customer_invoice_scholarship_deduction  # noqa: F401
+from . import test_module_category  # noqa: F401

--- a/ssi_school_scholarship_deduction/tests/test_data_module_category.yaml
+++ b/ssi_school_scholarship_deduction/tests/test_data_module_category.yaml
@@ -1,6 +1,5 @@
 scenarios:
-  - name: "Deduction workflow/data ownership groups point to their own model
-      category"
+  - name: "Deduction workflow/data ownership groups point to their own model category"
     steps:
       - step: "Get school_scholarship_deduction_viewer_group by XML ID"
         action: "ref"
@@ -66,8 +65,7 @@ scenarios:
           name:
             type: "value"
             expected: "Company"
-      - step: "Assert deduction_company_child_group category_id and literal
-          name"
+      - step: "Assert deduction_company_child_group category_id and literal name"
         action: "assert"
         target: "deduction_company_child_group"
         asserts:
@@ -88,16 +86,16 @@ scenarios:
             type: "value"
             expected: "All"
 
-  - name: "New deduction categories are parented under the shared School
-      Scholarship categories"
+  - name:
+      "New deduction categories are parented under the shared School Scholarship
+      categories"
     steps:
-      - step: "Get school_scholarship_deduction_workflow_module_category by
-          XML ID"
+      - step: "Get school_scholarship_deduction_workflow_module_category by XML ID"
         action: "ref"
         xml_id: "ssi_school_scholarship_deduction.school_scholarship_deduction_workflow_module_category"
         save_as: "deduction_workflow_category"
-      - step: "Get school_scholarship_deduction_data_ownership_module_category
-          by XML ID"
+      - step:
+          "Get school_scholarship_deduction_data_ownership_module_category by XML ID"
         action: "ref"
         xml_id: "ssi_school_scholarship_deduction.school_scholarship_deduction_data_ownership_module_category"
         save_as: "deduction_data_ownership_category"
@@ -148,7 +146,8 @@ scenarios:
             [
               "category_id",
               "=",
-              "REF: ssi_school_scholarship.school_scholarship_data_ownership_module_category",
+              "REF:
+              ssi_school_scholarship.school_scholarship_data_ownership_module_category",
             ],
           ]
         save_as: "orphan_data_ownership_groups"

--- a/ssi_school_scholarship_deduction/tests/test_data_module_category.yaml
+++ b/ssi_school_scholarship_deduction/tests/test_data_module_category.yaml
@@ -136,9 +136,19 @@ scenarios:
         save_as: "orphan_workflow_groups"
         expect_count: 0
 
-  - name: "No res.groups still points at the shared data ownership category"
+  - name:
+      "Only the out-of-scope Deduction Recognition group still points at the shared data
+      ownership category"
     steps:
-      - step: "Search res.groups on the shared data ownership category"
+      - step:
+          "Get the deliberately out-of-scope Deduction Recognition Operating Unit
+          group's id"
+        action: "ref"
+        xml_id: "ssi_school_scholarship_deduction_operating_unit.school_scholarship_deduction_recognition_operating_unit_group"
+        save_as: "recognition_ou_group"
+      - step:
+          "Search res.groups on the shared data ownership category, excluding the
+          deliberately out-of-scope Recognition group"
         action: "search"
         model: "res.groups"
         domain:
@@ -149,6 +159,7 @@ scenarios:
               "REF:
               ssi_school_scholarship.school_scholarship_data_ownership_module_category",
             ],
+            ["id", "!=", "REC: recognition_ou_group.id"],
           ]
         save_as: "orphan_data_ownership_groups"
         expect_count: 0

--- a/ssi_school_scholarship_deduction/tests/test_data_module_category.yaml
+++ b/ssi_school_scholarship_deduction/tests/test_data_module_category.yaml
@@ -1,0 +1,155 @@
+scenarios:
+  - name: "Deduction workflow/data ownership groups point to their own model
+      category"
+    steps:
+      - step: "Get school_scholarship_deduction_viewer_group by XML ID"
+        action: "ref"
+        xml_id: "ssi_school_scholarship_deduction.school_scholarship_deduction_viewer_group"
+        save_as: "deduction_viewer_group"
+      - step: "Get school_scholarship_deduction_user_group by XML ID"
+        action: "ref"
+        xml_id: "ssi_school_scholarship_deduction.school_scholarship_deduction_user_group"
+        save_as: "deduction_user_group"
+      - step: "Get school_scholarship_deduction_validator_group by XML ID"
+        action: "ref"
+        xml_id: "ssi_school_scholarship_deduction.school_scholarship_deduction_validator_group"
+        save_as: "deduction_validator_group"
+      - step: "Get school_scholarship_deduction_company_group by XML ID"
+        action: "ref"
+        xml_id: "ssi_school_scholarship_deduction.school_scholarship_deduction_company_group"
+        save_as: "deduction_company_group"
+      - step: "Get school_scholarship_deduction_company_child_group by XML ID"
+        action: "ref"
+        xml_id: "ssi_school_scholarship_deduction.school_scholarship_deduction_company_child_group"
+        save_as: "deduction_company_child_group"
+      - step: "Get school_scholarship_deduction_all_group by XML ID"
+        action: "ref"
+        xml_id: "ssi_school_scholarship_deduction.school_scholarship_deduction_all_group"
+        save_as: "deduction_all_group"
+      - step: "Assert deduction_viewer_group category_id and literal name"
+        action: "assert"
+        target: "deduction_viewer_group"
+        asserts:
+          category_id:
+            type: "m2o"
+            expected_xml_id: "ssi_school_scholarship_deduction.school_scholarship_deduction_workflow_module_category"
+          name:
+            type: "value"
+            expected: "Viewer"
+      - step: "Assert deduction_user_group category_id and literal name"
+        action: "assert"
+        target: "deduction_user_group"
+        asserts:
+          category_id:
+            type: "m2o"
+            expected_xml_id: "ssi_school_scholarship_deduction.school_scholarship_deduction_workflow_module_category"
+          name:
+            type: "value"
+            expected: "User"
+      - step: "Assert deduction_validator_group category_id and literal name"
+        action: "assert"
+        target: "deduction_validator_group"
+        asserts:
+          category_id:
+            type: "m2o"
+            expected_xml_id: "ssi_school_scholarship_deduction.school_scholarship_deduction_workflow_module_category"
+          name:
+            type: "value"
+            expected: "Validator"
+      - step: "Assert deduction_company_group category_id and literal name"
+        action: "assert"
+        target: "deduction_company_group"
+        asserts:
+          category_id:
+            type: "m2o"
+            expected_xml_id: "ssi_school_scholarship_deduction.school_scholarship_deduction_data_ownership_module_category"
+          name:
+            type: "value"
+            expected: "Company"
+      - step: "Assert deduction_company_child_group category_id and literal
+          name"
+        action: "assert"
+        target: "deduction_company_child_group"
+        asserts:
+          category_id:
+            type: "m2o"
+            expected_xml_id: "ssi_school_scholarship_deduction.school_scholarship_deduction_data_ownership_module_category"
+          name:
+            type: "value"
+            expected: "Company and All Child Companies"
+      - step: "Assert deduction_all_group category_id and literal name"
+        action: "assert"
+        target: "deduction_all_group"
+        asserts:
+          category_id:
+            type: "m2o"
+            expected_xml_id: "ssi_school_scholarship_deduction.school_scholarship_deduction_data_ownership_module_category"
+          name:
+            type: "value"
+            expected: "All"
+
+  - name: "New deduction categories are parented under the shared School
+      Scholarship categories"
+    steps:
+      - step: "Get school_scholarship_deduction_workflow_module_category by
+          XML ID"
+        action: "ref"
+        xml_id: "ssi_school_scholarship_deduction.school_scholarship_deduction_workflow_module_category"
+        save_as: "deduction_workflow_category"
+      - step: "Get school_scholarship_deduction_data_ownership_module_category
+          by XML ID"
+        action: "ref"
+        xml_id: "ssi_school_scholarship_deduction.school_scholarship_deduction_data_ownership_module_category"
+        save_as: "deduction_data_ownership_category"
+      - step: "Assert deduction_workflow_category parent_id and name"
+        action: "assert"
+        target: "deduction_workflow_category"
+        asserts:
+          parent_id:
+            type: "m2o"
+            expected_xml_id: "ssi_school_scholarship.school_scholarship_workflow_module_category"
+          name:
+            type: "value"
+            expected: "Scholarship Deduction"
+      - step: "Assert deduction_data_ownership_category parent_id and name"
+        action: "assert"
+        target: "deduction_data_ownership_category"
+        asserts:
+          parent_id:
+            type: "m2o"
+            expected_xml_id: "ssi_school_scholarship.school_scholarship_data_ownership_module_category"
+          name:
+            type: "value"
+            expected: "Scholarship Deduction"
+
+  - name: "No res.groups still points at the shared workflow category"
+    steps:
+      - step: "Search res.groups on the shared workflow category"
+        action: "search"
+        model: "res.groups"
+        domain:
+          [
+            [
+              "category_id",
+              "=",
+              "REF: ssi_school_scholarship.school_scholarship_workflow_module_category",
+            ],
+          ]
+        save_as: "orphan_workflow_groups"
+        expect_count: 0
+
+  - name: "No res.groups still points at the shared data ownership category"
+    steps:
+      - step: "Search res.groups on the shared data ownership category"
+        action: "search"
+        model: "res.groups"
+        domain:
+          [
+            [
+              "category_id",
+              "=",
+              "REF: ssi_school_scholarship.school_scholarship_data_ownership_module_category",
+            ],
+          ]
+        save_as: "orphan_data_ownership_groups"
+        expect_count: 0

--- a/ssi_school_scholarship_deduction/tests/test_module_category.py
+++ b/ssi_school_scholarship_deduction/tests/test_module_category.py
@@ -1,0 +1,19 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestModuleCategory(YamlTransactionCase):
+    """Scenario tests for the ``school_scholarship_deduction`` module
+    categories, run against the security data declared in
+    ``security/ir_module_category/`` and ``security/res_groups/``.
+    """
+
+    def test_module_category(self):
+        """Run the deduction category/group repointing scenarios."""
+        self.run_yaml_scenario("test_data_module_category.yaml")

--- a/ssi_school_scholarship_deduction_operating_unit/security/res_groups/school_scholarship_deduction.xml
+++ b/ssi_school_scholarship_deduction_operating_unit/security/res_groups/school_scholarship_deduction.xml
@@ -5,10 +5,10 @@
 <odoo>
 
 <record id="school_scholarship_deduction_operating_unit_group" model="res.groups">
-    <field name="name">Deduction Operating Unit</field>
+    <field name="name">Operating Unit</field>
     <field
             name="category_id"
-            ref="ssi_school_scholarship.school_scholarship_data_ownership_module_category"
+            ref="ssi_school_scholarship_deduction.school_scholarship_deduction_data_ownership_module_category"
         />
 </record>
 

--- a/ssi_school_scholarship_deduction_operating_unit/tests/__init__.py
+++ b/ssi_school_scholarship_deduction_operating_unit/tests/__init__.py
@@ -6,4 +6,5 @@ from . import (
     test_school_scholarship_deduction_operating_unit,
     test_ui_school_scholarship_deduction,
     test_ui_school_scholarship_deduction_recognition,
+    test_module_category,
 )

--- a/ssi_school_scholarship_deduction_operating_unit/tests/test_data_module_category.yaml
+++ b/ssi_school_scholarship_deduction_operating_unit/tests/test_data_module_category.yaml
@@ -1,0 +1,76 @@
+scenarios:
+  - name: "Deduction Operating Unit group points to the deduction data
+      ownership category"
+    steps:
+      - step: "Get school_scholarship_deduction_operating_unit_group by XML
+          ID"
+        action: "ref"
+        xml_id: "ssi_school_scholarship_deduction_operating_unit.school_scholarship_deduction_operating_unit_group"
+        save_as: "deduction_operating_unit_group"
+      - step: "Assert deduction_operating_unit_group category_id and
+          literal name"
+        action: "assert"
+        target: "deduction_operating_unit_group"
+        asserts:
+          category_id:
+            type: "m2o"
+            expected_xml_id: "ssi_school_scholarship_deduction.school_scholarship_deduction_data_ownership_module_category"
+          name:
+            type: "value"
+            expected: "Operating Unit"
+
+  - name: "Deduction Recognition Operating Unit group is intentionally left
+      out of scope"
+    steps:
+      - step: "Get school_scholarship_deduction_recognition_operating_unit_group
+          by XML ID"
+        action: "ref"
+        xml_id: "ssi_school_scholarship_deduction_operating_unit.school_scholarship_deduction_recognition_operating_unit_group"
+        save_as: "deduction_recognition_operating_unit_group"
+      - step: "Assert deduction_recognition_operating_unit_group still points
+          at the old shared data ownership category"
+        action: "assert"
+        target: "deduction_recognition_operating_unit_group"
+        asserts:
+          category_id:
+            type: "m2o"
+            expected_xml_id: "ssi_school_scholarship.school_scholarship_data_ownership_module_category"
+
+  - name: "No res.groups still points at the shared workflow category"
+    steps:
+      - step: "Search res.groups on the shared workflow category"
+        action: "search"
+        model: "res.groups"
+        domain:
+          [
+            [
+              "category_id",
+              "=",
+              "REF: ssi_school_scholarship.school_scholarship_workflow_module_category",
+            ],
+          ]
+        save_as: "orphan_workflow_groups"
+        expect_count: 0
+
+  - name: "Only the out-of-scope Deduction Recognition group still points at
+      the shared data ownership category"
+    steps:
+      - step: "Get deduction_recognition_operating_unit_group's id"
+        action: "ref"
+        xml_id: "ssi_school_scholarship_deduction_operating_unit.school_scholarship_deduction_recognition_operating_unit_group"
+        save_as: "recognition_ou_group"
+      - step: "Search res.groups on the shared data ownership category,
+          excluding the deliberately out-of-scope Recognition group"
+        action: "search"
+        model: "res.groups"
+        domain:
+          [
+            [
+              "category_id",
+              "=",
+              "REF: ssi_school_scholarship.school_scholarship_data_ownership_module_category",
+            ],
+            ["id", "!=", "REC: recognition_ou_group.id"],
+          ]
+        save_as: "orphan_data_ownership_groups"
+        expect_count: 0

--- a/ssi_school_scholarship_deduction_operating_unit/tests/test_data_module_category.yaml
+++ b/ssi_school_scholarship_deduction_operating_unit/tests/test_data_module_category.yaml
@@ -1,14 +1,12 @@
 scenarios:
-  - name: "Deduction Operating Unit group points to the deduction data
-      ownership category"
+  - name:
+      "Deduction Operating Unit group points to the deduction data ownership category"
     steps:
-      - step: "Get school_scholarship_deduction_operating_unit_group by XML
-          ID"
+      - step: "Get school_scholarship_deduction_operating_unit_group by XML ID"
         action: "ref"
         xml_id: "ssi_school_scholarship_deduction_operating_unit.school_scholarship_deduction_operating_unit_group"
         save_as: "deduction_operating_unit_group"
-      - step: "Assert deduction_operating_unit_group category_id and
-          literal name"
+      - step: "Assert deduction_operating_unit_group category_id and literal name"
         action: "assert"
         target: "deduction_operating_unit_group"
         asserts:
@@ -19,16 +17,17 @@ scenarios:
             type: "value"
             expected: "Operating Unit"
 
-  - name: "Deduction Recognition Operating Unit group is intentionally left
-      out of scope"
+  - name:
+      "Deduction Recognition Operating Unit group is intentionally left out of scope"
     steps:
-      - step: "Get school_scholarship_deduction_recognition_operating_unit_group
-          by XML ID"
+      - step:
+          "Get school_scholarship_deduction_recognition_operating_unit_group by XML ID"
         action: "ref"
         xml_id: "ssi_school_scholarship_deduction_operating_unit.school_scholarship_deduction_recognition_operating_unit_group"
         save_as: "deduction_recognition_operating_unit_group"
-      - step: "Assert deduction_recognition_operating_unit_group still points
-          at the old shared data ownership category"
+      - step:
+          "Assert deduction_recognition_operating_unit_group still points at the old
+          shared data ownership category"
         action: "assert"
         target: "deduction_recognition_operating_unit_group"
         asserts:
@@ -52,15 +51,17 @@ scenarios:
         save_as: "orphan_workflow_groups"
         expect_count: 0
 
-  - name: "Only the out-of-scope Deduction Recognition group still points at
-      the shared data ownership category"
+  - name:
+      "Only the out-of-scope Deduction Recognition group still points at the shared data
+      ownership category"
     steps:
       - step: "Get deduction_recognition_operating_unit_group's id"
         action: "ref"
         xml_id: "ssi_school_scholarship_deduction_operating_unit.school_scholarship_deduction_recognition_operating_unit_group"
         save_as: "recognition_ou_group"
-      - step: "Search res.groups on the shared data ownership category,
-          excluding the deliberately out-of-scope Recognition group"
+      - step:
+          "Search res.groups on the shared data ownership category, excluding the
+          deliberately out-of-scope Recognition group"
         action: "search"
         model: "res.groups"
         domain:
@@ -68,7 +69,8 @@ scenarios:
             [
               "category_id",
               "=",
-              "REF: ssi_school_scholarship.school_scholarship_data_ownership_module_category",
+              "REF:
+              ssi_school_scholarship.school_scholarship_data_ownership_module_category",
             ],
             ["id", "!=", "REC: recognition_ou_group.id"],
           ]

--- a/ssi_school_scholarship_deduction_operating_unit/tests/test_module_category.py
+++ b/ssi_school_scholarship_deduction_operating_unit/tests/test_module_category.py
@@ -1,0 +1,20 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestModuleCategory(YamlTransactionCase):
+    """Scenario tests asserting the deduction Operating Unit group is
+    repointed to the deduction-specific data ownership category, while
+    the out-of-scope Deduction Recognition Operating Unit group is left
+    untouched on the old shared category.
+    """
+
+    def test_module_category(self):
+        """Run the deduction Operating Unit group repointing scenarios."""
+        self.run_yaml_scenario("test_data_module_category.yaml")

--- a/ssi_school_scholarship_disbursement/__manifest__.py
+++ b/ssi_school_scholarship_disbursement/__manifest__.py
@@ -21,6 +21,7 @@
         "web_tour",
     ],
     "data": [
+        "security/ir_module_category/school_scholarship_disbursement.xml",
         "security/res_groups/school_scholarship_disbursement.xml",
         "security/ir_model_access/school_scholarship_disbursement.xml",
         "security/ir_model_access/school_scholarship_disbursement_line.xml",

--- a/ssi_school_scholarship_disbursement/security/ir_module_category/school_scholarship_disbursement.xml
+++ b/ssi_school_scholarship_disbursement/security/ir_module_category/school_scholarship_disbursement.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+<record
+        id="school_scholarship_disbursement_workflow_module_category"
+        model="ir.module.category"
+    >
+    <field name="name">Scholarship Disbursement</field>
+    <field
+            name="parent_id"
+            ref="ssi_school_scholarship.school_scholarship_workflow_module_category"
+        />
+</record>
+
+<record
+        id="school_scholarship_disbursement_data_ownership_module_category"
+        model="ir.module.category"
+    >
+    <field name="name">Scholarship Disbursement</field>
+    <field
+            name="parent_id"
+            ref="ssi_school_scholarship.school_scholarship_data_ownership_module_category"
+        />
+</record>
+</odoo>

--- a/ssi_school_scholarship_disbursement/security/res_groups/school_scholarship_disbursement.xml
+++ b/ssi_school_scholarship_disbursement/security/res_groups/school_scholarship_disbursement.xml
@@ -5,18 +5,18 @@
 <odoo>
 <!-- Workflow -->
 <record id="school_scholarship_disbursement_viewer_group" model="res.groups">
-    <field name="name">Disbursement Viewer</field>
+    <field name="name">Viewer</field>
     <field
             name="category_id"
-            ref="ssi_school_scholarship.school_scholarship_workflow_module_category"
+            ref="school_scholarship_disbursement_workflow_module_category"
         />
 </record>
 
 <record id="school_scholarship_disbursement_user_group" model="res.groups">
-    <field name="name">Disbursement User</field>
+    <field name="name">User</field>
     <field
             name="category_id"
-            ref="ssi_school_scholarship.school_scholarship_workflow_module_category"
+            ref="school_scholarship_disbursement_workflow_module_category"
         />
     <field
             name="implied_ids"
@@ -25,10 +25,10 @@
 </record>
 
 <record id="school_scholarship_disbursement_validator_group" model="res.groups">
-    <field name="name">Disbursement Validator</field>
+    <field name="name">Validator</field>
     <field
             name="category_id"
-            ref="ssi_school_scholarship.school_scholarship_workflow_module_category"
+            ref="school_scholarship_disbursement_workflow_module_category"
         />
     <field
             name="implied_ids"
@@ -42,18 +42,21 @@
 
 <!-- Data Ownership -->
 <record id="school_scholarship_disbursement_company_group" model="res.groups">
-    <field name="name">Disbursement Company</field>
+    <field name="name">Company</field>
     <field
             name="category_id"
-            ref="ssi_school_scholarship.school_scholarship_data_ownership_module_category"
+            ref="school_scholarship_disbursement_data_ownership_module_category"
         />
 </record>
 
-<record id="school_scholarship_disbursement_company_child_group" model="res.groups">
-    <field name="name">Disbursement Company and All Child Companies</field>
+<record
+        id="school_scholarship_disbursement_company_child_group"
+        model="res.groups"
+    >
+    <field name="name">Company and All Child Companies</field>
     <field
             name="category_id"
-            ref="ssi_school_scholarship.school_scholarship_data_ownership_module_category"
+            ref="school_scholarship_disbursement_data_ownership_module_category"
         />
     <field
             name="implied_ids"
@@ -62,10 +65,10 @@
 </record>
 
 <record id="school_scholarship_disbursement_all_group" model="res.groups">
-    <field name="name">Disbursement All</field>
+    <field name="name">All</field>
     <field
             name="category_id"
-            ref="ssi_school_scholarship.school_scholarship_data_ownership_module_category"
+            ref="school_scholarship_disbursement_data_ownership_module_category"
         />
     <field
             name="implied_ids"

--- a/ssi_school_scholarship_disbursement/security/res_groups/school_scholarship_disbursement.xml
+++ b/ssi_school_scholarship_disbursement/security/res_groups/school_scholarship_disbursement.xml
@@ -49,10 +49,7 @@
         />
 </record>
 
-<record
-        id="school_scholarship_disbursement_company_child_group"
-        model="res.groups"
-    >
+<record id="school_scholarship_disbursement_company_child_group" model="res.groups">
     <field name="name">Company and All Child Companies</field>
     <field
             name="category_id"

--- a/ssi_school_scholarship_disbursement/tests/__init__.py
+++ b/ssi_school_scholarship_disbursement/tests/__init__.py
@@ -4,3 +4,4 @@
 
 from . import test_school_scholarship_disbursement  # noqa: F401
 from . import test_ui_school_scholarship_disbursement  # noqa: F401
+from . import test_module_category  # noqa: F401

--- a/ssi_school_scholarship_disbursement/tests/test_data_module_category.yaml
+++ b/ssi_school_scholarship_disbursement/tests/test_data_module_category.yaml
@@ -1,6 +1,6 @@
 scenarios:
-  - name: "Disbursement workflow/data ownership groups point to their own
-      model category"
+  - name:
+      "Disbursement workflow/data ownership groups point to their own model category"
     steps:
       - step: "Get school_scholarship_disbursement_viewer_group by XML ID"
         action: "ref"
@@ -18,8 +18,7 @@ scenarios:
         action: "ref"
         xml_id: "ssi_school_scholarship_disbursement.school_scholarship_disbursement_company_group"
         save_as: "disbursement_company_group"
-      - step: "Get school_scholarship_disbursement_company_child_group by XML
-          ID"
+      - step: "Get school_scholarship_disbursement_company_child_group by XML ID"
         action: "ref"
         xml_id: "ssi_school_scholarship_disbursement.school_scholarship_disbursement_company_child_group"
         save_as: "disbursement_company_child_group"
@@ -27,8 +26,7 @@ scenarios:
         action: "ref"
         xml_id: "ssi_school_scholarship_disbursement.school_scholarship_disbursement_all_group"
         save_as: "disbursement_all_group"
-      - step: "Assert disbursement_viewer_group category_id and literal
-          name"
+      - step: "Assert disbursement_viewer_group category_id and literal name"
         action: "assert"
         target: "disbursement_viewer_group"
         asserts:
@@ -48,8 +46,7 @@ scenarios:
           name:
             type: "value"
             expected: "User"
-      - step: "Assert disbursement_validator_group category_id and literal
-          name"
+      - step: "Assert disbursement_validator_group category_id and literal name"
         action: "assert"
         target: "disbursement_validator_group"
         asserts:
@@ -59,8 +56,7 @@ scenarios:
           name:
             type: "value"
             expected: "Validator"
-      - step: "Assert disbursement_company_group category_id and literal
-          name"
+      - step: "Assert disbursement_company_group category_id and literal name"
         action: "assert"
         target: "disbursement_company_group"
         asserts:
@@ -70,8 +66,7 @@ scenarios:
           name:
             type: "value"
             expected: "Company"
-      - step: "Assert disbursement_company_child_group category_id and
-          literal name"
+      - step: "Assert disbursement_company_child_group category_id and literal name"
         action: "assert"
         target: "disbursement_company_child_group"
         asserts:
@@ -92,17 +87,16 @@ scenarios:
             type: "value"
             expected: "All"
 
-  - name: "New disbursement categories are parented under the shared School
-      Scholarship categories"
+  - name:
+      "New disbursement categories are parented under the shared School Scholarship
+      categories"
     steps:
-      - step: "Get
-          school_scholarship_disbursement_workflow_module_category by XML ID"
+      - step: "Get school_scholarship_disbursement_workflow_module_category by XML ID"
         action: "ref"
         xml_id: "ssi_school_scholarship_disbursement.school_scholarship_disbursement_workflow_module_category"
         save_as: "disbursement_workflow_category"
-      - step: "Get
-          school_scholarship_disbursement_data_ownership_module_category by
-          XML ID"
+      - step:
+          "Get school_scholarship_disbursement_data_ownership_module_category by XML ID"
         action: "ref"
         xml_id: "ssi_school_scholarship_disbursement.school_scholarship_disbursement_data_ownership_module_category"
         save_as: "disbursement_data_ownership_category"
@@ -116,8 +110,7 @@ scenarios:
           name:
             type: "value"
             expected: "Scholarship Disbursement"
-      - step: "Assert disbursement_data_ownership_category parent_id and
-          name"
+      - step: "Assert disbursement_data_ownership_category parent_id and name"
         action: "assert"
         target: "disbursement_data_ownership_category"
         asserts:
@@ -154,7 +147,8 @@ scenarios:
             [
               "category_id",
               "=",
-              "REF: ssi_school_scholarship.school_scholarship_data_ownership_module_category",
+              "REF:
+              ssi_school_scholarship.school_scholarship_data_ownership_module_category",
             ],
           ]
         save_as: "orphan_data_ownership_groups"

--- a/ssi_school_scholarship_disbursement/tests/test_data_module_category.yaml
+++ b/ssi_school_scholarship_disbursement/tests/test_data_module_category.yaml
@@ -1,0 +1,161 @@
+scenarios:
+  - name: "Disbursement workflow/data ownership groups point to their own
+      model category"
+    steps:
+      - step: "Get school_scholarship_disbursement_viewer_group by XML ID"
+        action: "ref"
+        xml_id: "ssi_school_scholarship_disbursement.school_scholarship_disbursement_viewer_group"
+        save_as: "disbursement_viewer_group"
+      - step: "Get school_scholarship_disbursement_user_group by XML ID"
+        action: "ref"
+        xml_id: "ssi_school_scholarship_disbursement.school_scholarship_disbursement_user_group"
+        save_as: "disbursement_user_group"
+      - step: "Get school_scholarship_disbursement_validator_group by XML ID"
+        action: "ref"
+        xml_id: "ssi_school_scholarship_disbursement.school_scholarship_disbursement_validator_group"
+        save_as: "disbursement_validator_group"
+      - step: "Get school_scholarship_disbursement_company_group by XML ID"
+        action: "ref"
+        xml_id: "ssi_school_scholarship_disbursement.school_scholarship_disbursement_company_group"
+        save_as: "disbursement_company_group"
+      - step: "Get school_scholarship_disbursement_company_child_group by XML
+          ID"
+        action: "ref"
+        xml_id: "ssi_school_scholarship_disbursement.school_scholarship_disbursement_company_child_group"
+        save_as: "disbursement_company_child_group"
+      - step: "Get school_scholarship_disbursement_all_group by XML ID"
+        action: "ref"
+        xml_id: "ssi_school_scholarship_disbursement.school_scholarship_disbursement_all_group"
+        save_as: "disbursement_all_group"
+      - step: "Assert disbursement_viewer_group category_id and literal
+          name"
+        action: "assert"
+        target: "disbursement_viewer_group"
+        asserts:
+          category_id:
+            type: "m2o"
+            expected_xml_id: "ssi_school_scholarship_disbursement.school_scholarship_disbursement_workflow_module_category"
+          name:
+            type: "value"
+            expected: "Viewer"
+      - step: "Assert disbursement_user_group category_id and literal name"
+        action: "assert"
+        target: "disbursement_user_group"
+        asserts:
+          category_id:
+            type: "m2o"
+            expected_xml_id: "ssi_school_scholarship_disbursement.school_scholarship_disbursement_workflow_module_category"
+          name:
+            type: "value"
+            expected: "User"
+      - step: "Assert disbursement_validator_group category_id and literal
+          name"
+        action: "assert"
+        target: "disbursement_validator_group"
+        asserts:
+          category_id:
+            type: "m2o"
+            expected_xml_id: "ssi_school_scholarship_disbursement.school_scholarship_disbursement_workflow_module_category"
+          name:
+            type: "value"
+            expected: "Validator"
+      - step: "Assert disbursement_company_group category_id and literal
+          name"
+        action: "assert"
+        target: "disbursement_company_group"
+        asserts:
+          category_id:
+            type: "m2o"
+            expected_xml_id: "ssi_school_scholarship_disbursement.school_scholarship_disbursement_data_ownership_module_category"
+          name:
+            type: "value"
+            expected: "Company"
+      - step: "Assert disbursement_company_child_group category_id and
+          literal name"
+        action: "assert"
+        target: "disbursement_company_child_group"
+        asserts:
+          category_id:
+            type: "m2o"
+            expected_xml_id: "ssi_school_scholarship_disbursement.school_scholarship_disbursement_data_ownership_module_category"
+          name:
+            type: "value"
+            expected: "Company and All Child Companies"
+      - step: "Assert disbursement_all_group category_id and literal name"
+        action: "assert"
+        target: "disbursement_all_group"
+        asserts:
+          category_id:
+            type: "m2o"
+            expected_xml_id: "ssi_school_scholarship_disbursement.school_scholarship_disbursement_data_ownership_module_category"
+          name:
+            type: "value"
+            expected: "All"
+
+  - name: "New disbursement categories are parented under the shared School
+      Scholarship categories"
+    steps:
+      - step: "Get
+          school_scholarship_disbursement_workflow_module_category by XML ID"
+        action: "ref"
+        xml_id: "ssi_school_scholarship_disbursement.school_scholarship_disbursement_workflow_module_category"
+        save_as: "disbursement_workflow_category"
+      - step: "Get
+          school_scholarship_disbursement_data_ownership_module_category by
+          XML ID"
+        action: "ref"
+        xml_id: "ssi_school_scholarship_disbursement.school_scholarship_disbursement_data_ownership_module_category"
+        save_as: "disbursement_data_ownership_category"
+      - step: "Assert disbursement_workflow_category parent_id and name"
+        action: "assert"
+        target: "disbursement_workflow_category"
+        asserts:
+          parent_id:
+            type: "m2o"
+            expected_xml_id: "ssi_school_scholarship.school_scholarship_workflow_module_category"
+          name:
+            type: "value"
+            expected: "Scholarship Disbursement"
+      - step: "Assert disbursement_data_ownership_category parent_id and
+          name"
+        action: "assert"
+        target: "disbursement_data_ownership_category"
+        asserts:
+          parent_id:
+            type: "m2o"
+            expected_xml_id: "ssi_school_scholarship.school_scholarship_data_ownership_module_category"
+          name:
+            type: "value"
+            expected: "Scholarship Disbursement"
+
+  - name: "No res.groups still points at the shared workflow category"
+    steps:
+      - step: "Search res.groups on the shared workflow category"
+        action: "search"
+        model: "res.groups"
+        domain:
+          [
+            [
+              "category_id",
+              "=",
+              "REF: ssi_school_scholarship.school_scholarship_workflow_module_category",
+            ],
+          ]
+        save_as: "orphan_workflow_groups"
+        expect_count: 0
+
+  - name: "No res.groups still points at the shared data ownership category"
+    steps:
+      - step: "Search res.groups on the shared data ownership category"
+        action: "search"
+        model: "res.groups"
+        domain:
+          [
+            [
+              "category_id",
+              "=",
+              "REF: ssi_school_scholarship.school_scholarship_data_ownership_module_category",
+            ],
+          ]
+        save_as: "orphan_data_ownership_groups"
+        expect_count: 0

--- a/ssi_school_scholarship_disbursement/tests/test_data_module_category.yaml
+++ b/ssi_school_scholarship_disbursement/tests/test_data_module_category.yaml
@@ -137,9 +137,19 @@ scenarios:
         save_as: "orphan_workflow_groups"
         expect_count: 0
 
-  - name: "No res.groups still points at the shared data ownership category"
+  - name:
+      "Only the out-of-scope Deduction Recognition group still points at the shared data
+      ownership category"
     steps:
-      - step: "Search res.groups on the shared data ownership category"
+      - step:
+          "Get the deliberately out-of-scope Deduction Recognition Operating Unit
+          group's id"
+        action: "ref"
+        xml_id: "ssi_school_scholarship_deduction_operating_unit.school_scholarship_deduction_recognition_operating_unit_group"
+        save_as: "recognition_ou_group"
+      - step:
+          "Search res.groups on the shared data ownership category, excluding the
+          deliberately out-of-scope Recognition group"
         action: "search"
         model: "res.groups"
         domain:
@@ -150,6 +160,7 @@ scenarios:
               "REF:
               ssi_school_scholarship.school_scholarship_data_ownership_module_category",
             ],
+            ["id", "!=", "REC: recognition_ou_group.id"],
           ]
         save_as: "orphan_data_ownership_groups"
         expect_count: 0

--- a/ssi_school_scholarship_disbursement/tests/test_module_category.py
+++ b/ssi_school_scholarship_disbursement/tests/test_module_category.py
@@ -1,0 +1,19 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestModuleCategory(YamlTransactionCase):
+    """Scenario tests for the ``school_scholarship_disbursement`` module
+    categories, run against the security data declared in
+    ``security/ir_module_category/`` and ``security/res_groups/``.
+    """
+
+    def test_module_category(self):
+        """Run the disbursement category/group repointing scenarios."""
+        self.run_yaml_scenario("test_data_module_category.yaml")

--- a/ssi_school_scholarship_disbursement_operating_unit/security/res_groups/school_scholarship_disbursement.xml
+++ b/ssi_school_scholarship_disbursement_operating_unit/security/res_groups/school_scholarship_disbursement.xml
@@ -5,10 +5,10 @@
 <odoo>
 
 <record id="school_scholarship_disbursement_operating_unit_group" model="res.groups">
-    <field name="name">Disbursement Operating Unit</field>
+    <field name="name">Operating Unit</field>
     <field
             name="category_id"
-            ref="ssi_school_scholarship.school_scholarship_data_ownership_module_category"
+            ref="ssi_school_scholarship_disbursement.school_scholarship_disbursement_data_ownership_module_category"
         />
 </record>
 

--- a/ssi_school_scholarship_disbursement_operating_unit/tests/__init__.py
+++ b/ssi_school_scholarship_disbursement_operating_unit/tests/__init__.py
@@ -5,4 +5,5 @@
 from . import (
     test_school_scholarship_disbursement_operating_unit,
     test_ui_school_scholarship_disbursement,
+    test_module_category,
 )

--- a/ssi_school_scholarship_disbursement_operating_unit/tests/test_data_module_category.yaml
+++ b/ssi_school_scholarship_disbursement_operating_unit/tests/test_data_module_category.yaml
@@ -34,9 +34,19 @@ scenarios:
         save_as: "orphan_workflow_groups"
         expect_count: 0
 
-  - name: "No res.groups still points at the shared data ownership category"
+  - name:
+      "Only the out-of-scope Deduction Recognition group still points at the shared data
+      ownership category"
     steps:
-      - step: "Search res.groups on the shared data ownership category"
+      - step:
+          "Get the deliberately out-of-scope Deduction Recognition Operating Unit
+          group's id"
+        action: "ref"
+        xml_id: "ssi_school_scholarship_deduction_operating_unit.school_scholarship_deduction_recognition_operating_unit_group"
+        save_as: "recognition_ou_group"
+      - step:
+          "Search res.groups on the shared data ownership category, excluding the
+          deliberately out-of-scope Recognition group"
         action: "search"
         model: "res.groups"
         domain:
@@ -47,6 +57,7 @@ scenarios:
               "REF:
               ssi_school_scholarship.school_scholarship_data_ownership_module_category",
             ],
+            ["id", "!=", "REC: recognition_ou_group.id"],
           ]
         save_as: "orphan_data_ownership_groups"
         expect_count: 0

--- a/ssi_school_scholarship_disbursement_operating_unit/tests/test_data_module_category.yaml
+++ b/ssi_school_scholarship_disbursement_operating_unit/tests/test_data_module_category.yaml
@@ -1,14 +1,13 @@
 scenarios:
-  - name: "Disbursement Operating Unit group points to the disbursement data
-      ownership category"
+  - name:
+      "Disbursement Operating Unit group points to the disbursement data ownership
+      category"
     steps:
-      - step: "Get school_scholarship_disbursement_operating_unit_group by
-          XML ID"
+      - step: "Get school_scholarship_disbursement_operating_unit_group by XML ID"
         action: "ref"
         xml_id: "ssi_school_scholarship_disbursement_operating_unit.school_scholarship_disbursement_operating_unit_group"
         save_as: "disbursement_operating_unit_group"
-      - step: "Assert disbursement_operating_unit_group category_id and
-          literal name"
+      - step: "Assert disbursement_operating_unit_group category_id and literal name"
         action: "assert"
         target: "disbursement_operating_unit_group"
         asserts:
@@ -45,7 +44,8 @@ scenarios:
             [
               "category_id",
               "=",
-              "REF: ssi_school_scholarship.school_scholarship_data_ownership_module_category",
+              "REF:
+              ssi_school_scholarship.school_scholarship_data_ownership_module_category",
             ],
           ]
         save_as: "orphan_data_ownership_groups"

--- a/ssi_school_scholarship_disbursement_operating_unit/tests/test_data_module_category.yaml
+++ b/ssi_school_scholarship_disbursement_operating_unit/tests/test_data_module_category.yaml
@@ -1,0 +1,52 @@
+scenarios:
+  - name: "Disbursement Operating Unit group points to the disbursement data
+      ownership category"
+    steps:
+      - step: "Get school_scholarship_disbursement_operating_unit_group by
+          XML ID"
+        action: "ref"
+        xml_id: "ssi_school_scholarship_disbursement_operating_unit.school_scholarship_disbursement_operating_unit_group"
+        save_as: "disbursement_operating_unit_group"
+      - step: "Assert disbursement_operating_unit_group category_id and
+          literal name"
+        action: "assert"
+        target: "disbursement_operating_unit_group"
+        asserts:
+          category_id:
+            type: "m2o"
+            expected_xml_id: "ssi_school_scholarship_disbursement.school_scholarship_disbursement_data_ownership_module_category"
+          name:
+            type: "value"
+            expected: "Operating Unit"
+
+  - name: "No res.groups still points at the shared workflow category"
+    steps:
+      - step: "Search res.groups on the shared workflow category"
+        action: "search"
+        model: "res.groups"
+        domain:
+          [
+            [
+              "category_id",
+              "=",
+              "REF: ssi_school_scholarship.school_scholarship_workflow_module_category",
+            ],
+          ]
+        save_as: "orphan_workflow_groups"
+        expect_count: 0
+
+  - name: "No res.groups still points at the shared data ownership category"
+    steps:
+      - step: "Search res.groups on the shared data ownership category"
+        action: "search"
+        model: "res.groups"
+        domain:
+          [
+            [
+              "category_id",
+              "=",
+              "REF: ssi_school_scholarship.school_scholarship_data_ownership_module_category",
+            ],
+          ]
+        save_as: "orphan_data_ownership_groups"
+        expect_count: 0

--- a/ssi_school_scholarship_disbursement_operating_unit/tests/test_module_category.py
+++ b/ssi_school_scholarship_disbursement_operating_unit/tests/test_module_category.py
@@ -1,0 +1,20 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestModuleCategory(YamlTransactionCase):
+    """Scenario test asserting the disbursement Operating Unit group is
+    repointed to the disbursement-specific data ownership category.
+    """
+
+    def test_module_category(self):
+        """Run the disbursement Operating Unit group repointing
+        scenario.
+        """
+        self.run_yaml_scenario("test_data_module_category.yaml")

--- a/ssi_school_scholarship_operating_unit/security/res_groups/school_scholarship_award.xml
+++ b/ssi_school_scholarship_operating_unit/security/res_groups/school_scholarship_award.xml
@@ -8,7 +8,7 @@
     <field name="name">Operating Unit</field>
     <field
             name="category_id"
-            ref="ssi_school_scholarship.school_scholarship_data_ownership_module_category"
+            ref="ssi_school_scholarship.school_scholarship_award_data_ownership_module_category"
         />
 </record>
 

--- a/ssi_school_scholarship_operating_unit/tests/__init__.py
+++ b/ssi_school_scholarship_operating_unit/tests/__init__.py
@@ -8,4 +8,5 @@ from . import (
     test_ui_school_scholarship_funding_source,
     test_ui_school_scholarship_program,
     test_ui_school_scholarship_award,
+    test_module_category,
 )

--- a/ssi_school_scholarship_operating_unit/tests/test_data_module_category.yaml
+++ b/ssi_school_scholarship_operating_unit/tests/test_data_module_category.yaml
@@ -1,13 +1,11 @@
 scenarios:
-  - name: "Award Operating Unit group points to the award data ownership
-      category"
+  - name: "Award Operating Unit group points to the award data ownership category"
     steps:
       - step: "Get school_scholarship_award_operating_unit_group by XML ID"
         action: "ref"
         xml_id: "ssi_school_scholarship_operating_unit.school_scholarship_award_operating_unit_group"
         save_as: "award_operating_unit_group"
-      - step: "Assert award_operating_unit_group category_id and literal
-          name"
+      - step: "Assert award_operating_unit_group category_id and literal name"
         action: "assert"
         target: "award_operating_unit_group"
         asserts:

--- a/ssi_school_scholarship_operating_unit/tests/test_data_module_category.yaml
+++ b/ssi_school_scholarship_operating_unit/tests/test_data_module_category.yaml
@@ -1,0 +1,19 @@
+scenarios:
+  - name: "Award Operating Unit group points to the award data ownership
+      category"
+    steps:
+      - step: "Get school_scholarship_award_operating_unit_group by XML ID"
+        action: "ref"
+        xml_id: "ssi_school_scholarship_operating_unit.school_scholarship_award_operating_unit_group"
+        save_as: "award_operating_unit_group"
+      - step: "Assert award_operating_unit_group category_id and literal
+          name"
+        action: "assert"
+        target: "award_operating_unit_group"
+        asserts:
+          category_id:
+            type: "m2o"
+            expected_xml_id: "ssi_school_scholarship.school_scholarship_award_data_ownership_module_category"
+          name:
+            type: "value"
+            expected: "Operating Unit"

--- a/ssi_school_scholarship_operating_unit/tests/test_module_category.py
+++ b/ssi_school_scholarship_operating_unit/tests/test_module_category.py
@@ -1,0 +1,18 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestModuleCategory(YamlTransactionCase):
+    """Scenario test asserting the award Operating Unit group is
+    repointed to the award-specific data ownership category.
+    """
+
+    def test_module_category(self):
+        """Run the award Operating Unit group repointing scenario."""
+        self.run_yaml_scenario("test_data_module_category.yaml")


### PR DESCRIPTION
## Ringkasan

Tiap model transaksional scholarship (`school_scholarship_award`,
`school_scholarship_deduction`, `school_scholarship_disbursement`) kini punya
sepasang `ir.module.category` sendiri (workflow + data ownership), bukan
menumpang dua kategori bersama milik `ssi_school_scholarship`. Ini
memperbaiki dropdown group pada form user, yang sebelumnya jatuh ke blok
generik "Other" karena `res.users.get_groups_by_application()` tidak bisa
mengurutkan 18 group workflow/data-ownership secara total begitu lebih dari
satu model memakai kategori yang sama.

## Perubahan

- `ssi_school_scholarship`, `ssi_school_scholarship_deduction`,
  `ssi_school_scholarship_disbursement`: tambah `security/ir_module_category/`
  per model (dimuat sebelum `res_groups/` di manifest), repoint
  `category_id` 18 group workflow/data ownership, ganti `name` group jadi
  literal (`Viewer`/`User`/`Validator`/`Company`/`Company and All Child
  Companies`/`All`).
- `ssi_school_scholarship_operating_unit`,
  `ssi_school_scholarship_deduction_operating_unit`,
  `ssi_school_scholarship_disbursement_operating_unit`: repoint
  `category_id` 3 group Operating Unit ke kategori data ownership model
  masing-masing, ganti `name` jadi `Operating Unit`.
- XML ID group/kategori **tidak berubah**; dua kategori lama tetap ada
  sebagai induk kategori baru.
- `school_scholarship_deduction_recognition_operating_unit_group` sengaja
  **tidak** disentuh (di luar lingkup, ditangani issue terpisah).
- Unit test YAML baru (`test_data_module_category.yaml`) di keenam modul.

## Verifikasi

`verify-module.sh` 14.0 untuk keenam modul: `LOLOS: 0 ERROR` (lihat
komentar di issue/PR untuk baris `#VALIDATOR`).

Closes #47