### PR TITLE
[UPD] Give school_scholarship_deduction_recognition its own workflow group

### DIFF
--- a/ssi_school_scholarship_deduction/__manifest__.py
+++ b/ssi_school_scholarship_deduction/__manifest__.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     "name": "School Scholarship Deduction",
-    "version": "14.0.1.4.3",
+    "version": "14.0.1.4.4",
     "website": "https://simetri-sinergi.id",
     # pylint: disable=line-too-long
     "author": "PT. Simetri Sinergi Indonesia, OpenSynergy Indonesia, Odoo Community Association (OCA)",  # noqa: B950
@@ -24,7 +24,9 @@
     ],
     "data": [
         "security/ir_module_category/school_scholarship_deduction.xml",
+        "security/ir_module_category/school_scholarship_deduction_recognition.xml",
         "security/res_groups/school_scholarship_deduction.xml",
+        "security/res_groups/school_scholarship_deduction_recognition.xml",
         "security/ir_model_access/school_scholarship_deduction.xml",
         "security/ir_model_access/school_scholarship_deduction_line.xml",
         "security/ir_model_access/school_scholarship_deduction_allocation.xml",

--- a/ssi_school_scholarship_deduction/migrations/14.0.1.4.4/post-migrate.py
+++ b/ssi_school_scholarship_deduction/migrations/14.0.1.4.4/post-migrate.py
@@ -1,0 +1,104 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+#
+# Migration: 14.0.1.4.3 -> 14.0.1.4.4
+#
+# Changes: school_scholarship_deduction_recognition gained its own
+#          workflow/data ownership group ladder (Viewer/User/Validator,
+#          Company/Company and All Child Companies/All), replacing the
+#          school_scholarship_deduction_* groups it used to piggyback
+#          on for every ACL, ir.rule and menu of its own. This script
+#          copies each user's existing school_scholarship_deduction_*
+#          membership onto the equivalent new
+#          school_scholarship_deduction_recognition_* group so
+#          authorization that used to come from Deduction keeps
+#          working for Recognition without a manual re-grant.
+
+import logging
+
+from openupgradelib import openupgrade
+
+_logger = logging.getLogger(__name__)
+
+# (old deduction group, new recognition group) pairs, one per rung of
+# the workflow and data ownership ladders.
+_GROUP_XMLID_PAIRS = [
+    (
+        "school_scholarship_deduction_viewer_group",
+        "school_scholarship_deduction_recognition_viewer_group",
+    ),
+    (
+        "school_scholarship_deduction_user_group",
+        "school_scholarship_deduction_recognition_user_group",
+    ),
+    (
+        "school_scholarship_deduction_validator_group",
+        "school_scholarship_deduction_recognition_validator_group",
+    ),
+    (
+        "school_scholarship_deduction_company_group",
+        "school_scholarship_deduction_recognition_company_group",
+    ),
+    (
+        "school_scholarship_deduction_company_child_group",
+        "school_scholarship_deduction_recognition_company_child_group",
+    ),
+    (
+        "school_scholarship_deduction_all_group",
+        "school_scholarship_deduction_recognition_all_group",
+    ),
+]
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    """Copy Deduction group membership onto the new Recognition groups.
+
+    Every user already granted one of the six
+    ``school_scholarship_deduction_*`` groups is added to the
+    equivalent new ``school_scholarship_deduction_recognition_*``
+    group introduced by this release. Runs after this module's own
+    data files (including the new groups) have been loaded, so every
+    XML ID resolves.
+
+    :param env: the migration environment
+    :param version: the version being migrated to (unused)
+    :return: nothing; updates ``res_groups_users_rel`` rows
+    """
+    module = "ssi_school_scholarship_deduction"
+    for deduction_xmlid, recognition_xmlid in _GROUP_XMLID_PAIRS:
+        deduction_group = env.ref(
+            "%s.%s" % (module, deduction_xmlid), raise_if_not_found=False
+        )
+        recognition_group = env.ref(
+            "%s.%s" % (module, recognition_xmlid), raise_if_not_found=False
+        )
+        if not deduction_group or not recognition_group:
+            _logger.warning(
+                "Skipping %s -> %s: one of the groups was not found.",
+                deduction_xmlid,
+                recognition_xmlid,
+            )
+            continue
+        openupgrade.logged_query(
+            env.cr,
+            """
+            INSERT INTO res_groups_users_rel (gid, uid)
+            SELECT %s, src.uid
+            FROM res_groups_users_rel AS src
+            WHERE src.gid = %s
+              AND NOT EXISTS (
+                  SELECT 1
+                  FROM res_groups_users_rel AS dst
+                  WHERE dst.gid = %s AND dst.uid = src.uid
+              )
+            """,
+            (recognition_group.id, deduction_group.id, recognition_group.id),
+        )
+        _logger.info(
+            "Copied %s membership onto %s (%s row(s) added).",
+            deduction_xmlid,
+            recognition_xmlid,
+            env.cr.rowcount,
+        )

--- a/ssi_school_scholarship_deduction/security/ir_model_access/school_scholarship_deduction_recognition.xml
+++ b/ssi_school_scholarship_deduction/security/ir_model_access/school_scholarship_deduction_recognition.xml
@@ -20,7 +20,7 @@
     >
     <field name="name">school_scholarship_deduction_recognition - user</field>
     <field name="model_id" ref="model_school_scholarship_deduction_recognition" />
-    <field name="group_id" ref="school_scholarship_deduction_user_group" />
+    <field name="group_id" ref="school_scholarship_deduction_recognition_user_group" />
     <field name="perm_read" eval="1" />
     <field name="perm_create" eval="1" />
     <field name="perm_write" eval="1" />

--- a/ssi_school_scholarship_deduction/security/ir_module_category/school_scholarship_deduction_recognition.xml
+++ b/ssi_school_scholarship_deduction/security/ir_module_category/school_scholarship_deduction_recognition.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+<record
+        id="school_scholarship_deduction_recognition_workflow_module_category"
+        model="ir.module.category"
+    >
+    <field name="name">Scholarship Deduction Recognition</field>
+    <field
+            name="parent_id"
+            ref="ssi_school_scholarship.school_scholarship_workflow_module_category"
+        />
+</record>
+
+<record
+        id="school_scholarship_deduction_recognition_data_ownership_module_category"
+        model="ir.module.category"
+    >
+    <field name="name">Scholarship Deduction Recognition</field>
+    <field
+            name="parent_id"
+            ref="ssi_school_scholarship.school_scholarship_data_ownership_module_category"
+        />
+</record>
+</odoo>

--- a/ssi_school_scholarship_deduction/security/ir_rule/school_scholarship_deduction_recognition.xml
+++ b/ssi_school_scholarship_deduction/security/ir_rule/school_scholarship_deduction_recognition.xml
@@ -26,7 +26,7 @@
     <field name="model_id" ref="model_school_scholarship_deduction_recognition" />
     <field
             name="groups"
-            eval="[(4, ref('school_scholarship_deduction_company_group'))]"
+            eval="[(4, ref('school_scholarship_deduction_recognition_company_group'))]"
         />
     <field name="domain_force">[('company_id','=',user.company_id.id)]</field>
     <field name="perm_unlink" eval="1" />
@@ -42,7 +42,7 @@
     <field name="model_id" ref="model_school_scholarship_deduction_recognition" />
     <field
             name="groups"
-            eval="[(4, ref('school_scholarship_deduction_company_child_group'))]"
+            eval="[(4, ref('school_scholarship_deduction_recognition_company_child_group'))]"
         />
     <field name="domain_force">[('company_id','in',user.company_ids.ids)]</field>
     <field name="perm_unlink" eval="1" />
@@ -54,7 +54,10 @@
 <record id="school_scholarship_deduction_recognition_all_rule" model="ir.rule">
     <field name="name">School Scholarship Deduction Recognition - All</field>
     <field name="model_id" ref="model_school_scholarship_deduction_recognition" />
-    <field name="groups" eval="[(4, ref('school_scholarship_deduction_all_group'))]" />
+    <field
+            name="groups"
+            eval="[(4, ref('school_scholarship_deduction_recognition_all_group'))]"
+        />
     <field name="domain_force">[(1,'=',1)]</field>
     <field name="perm_unlink" eval="1" />
     <field name="perm_write" eval="1" />

--- a/ssi_school_scholarship_deduction/security/res_groups/school_scholarship_deduction_recognition.xml
+++ b/ssi_school_scholarship_deduction/security/res_groups/school_scholarship_deduction_recognition.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+<!-- Workflow -->
+<record id="school_scholarship_deduction_recognition_viewer_group" model="res.groups">
+    <field name="name">Viewer</field>
+    <field
+            name="category_id"
+            ref="school_scholarship_deduction_recognition_workflow_module_category"
+        />
+</record>
+
+<record id="school_scholarship_deduction_recognition_user_group" model="res.groups">
+    <field name="name">User</field>
+    <field
+            name="category_id"
+            ref="school_scholarship_deduction_recognition_workflow_module_category"
+        />
+    <field
+            name="implied_ids"
+            eval="[(4, ref('school_scholarship_deduction_recognition_viewer_group'))]"
+        />
+</record>
+
+<record
+        id="school_scholarship_deduction_recognition_validator_group"
+        model="res.groups"
+    >
+    <field name="name">Validator</field>
+    <field
+            name="category_id"
+            ref="school_scholarship_deduction_recognition_workflow_module_category"
+        />
+    <field
+            name="implied_ids"
+            eval="[(4, ref('school_scholarship_deduction_recognition_user_group'))]"
+        />
+    <field
+            name="users"
+            eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"
+        />
+</record>
+
+<!-- Data Ownership -->
+<record id="school_scholarship_deduction_recognition_company_group" model="res.groups">
+    <field name="name">Company</field>
+    <field
+            name="category_id"
+            ref="school_scholarship_deduction_recognition_data_ownership_module_category"
+        />
+</record>
+
+<record
+        id="school_scholarship_deduction_recognition_company_child_group"
+        model="res.groups"
+    >
+    <field name="name">Company and All Child Companies</field>
+    <field
+            name="category_id"
+            ref="school_scholarship_deduction_recognition_data_ownership_module_category"
+        />
+    <field
+            name="implied_ids"
+            eval="[(4, ref('school_scholarship_deduction_recognition_company_group'))]"
+        />
+</record>
+
+<record id="school_scholarship_deduction_recognition_all_group" model="res.groups">
+    <field name="name">All</field>
+    <field
+            name="category_id"
+            ref="school_scholarship_deduction_recognition_data_ownership_module_category"
+        />
+    <field
+            name="implied_ids"
+            eval="[(4, ref('school_scholarship_deduction_recognition_company_child_group'))]"
+        />
+    <field
+            name="users"
+            eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"
+        />
+</record>
+</odoo>

--- a/ssi_school_scholarship_deduction/tests/__init__.py
+++ b/ssi_school_scholarship_deduction/tests/__init__.py
@@ -7,6 +7,7 @@ from . import test_ui_school_scholarship_deduction  # noqa: F401
 from . import test_school_scholarship_award_create_due_deduction  # noqa: F401
 from . import test_ui_school_scholarship_award_create_due_deduction  # noqa: F401
 from . import test_school_scholarship_deduction_recognition  # noqa: F401
+from . import test_school_scholarship_deduction_recognition_security  # noqa: F401
 from . import test_ui_school_scholarship_deduction_recognition  # noqa: F401
 from . import test_customer_invoice_scholarship_deduction  # noqa: F401
 from . import test_module_category  # noqa: F401

--- a/ssi_school_scholarship_deduction/tests/test_data_module_category.yaml
+++ b/ssi_school_scholarship_deduction/tests/test_data_module_category.yaml
@@ -136,19 +136,9 @@ scenarios:
         save_as: "orphan_workflow_groups"
         expect_count: 0
 
-  - name:
-      "Only the out-of-scope Deduction Recognition group still points at the shared data
-      ownership category"
+  - name: "No res.groups still points at the shared data ownership category"
     steps:
-      - step:
-          "Get the deliberately out-of-scope Deduction Recognition Operating Unit
-          group's id"
-        action: "ref"
-        xml_id: "ssi_school_scholarship_deduction_operating_unit.school_scholarship_deduction_recognition_operating_unit_group"
-        save_as: "recognition_ou_group"
-      - step:
-          "Search res.groups on the shared data ownership category, excluding the
-          deliberately out-of-scope Recognition group"
+      - step: "Search res.groups on the shared data ownership category"
         action: "search"
         model: "res.groups"
         domain:
@@ -159,7 +149,6 @@ scenarios:
               "REF:
               ssi_school_scholarship.school_scholarship_data_ownership_module_category",
             ],
-            ["id", "!=", "REC: recognition_ou_group.id"],
           ]
         save_as: "orphan_data_ownership_groups"
         expect_count: 0

--- a/ssi_school_scholarship_deduction/tests/test_data_school_scholarship_deduction_recognition_security.yaml
+++ b/ssi_school_scholarship_deduction/tests/test_data_school_scholarship_deduction_recognition_security.yaml
@@ -1,167 +1,20 @@
 options:
   auto_refresh: true
 
-# Shared fixture: one Deduction, owned by admin, replayed fresh before
-# every scenario below. Deliberately has no Lines -- creating a
-# Recognition only needs an existing Deduction id, not a fully worked
-# Deduction -- so the chain stops at the minimum required to satisfy
-# Award/Program/Deduction's own required fields.
-setup:
-  steps:
-    - step: "Get the admin user reference"
-      action: "ref"
-      xml_id: "base.user_admin"
-      save_as: "sec_admin"
-
-    - step: "Create the grade type"
-      action: "create"
-      model: "school_grade_type"
-      save_as: "sec_grade_type"
-      values:
-        name: "SEC Grade Type"
-        code: "SECGT"
-
-    - step: "Create the school"
-      action: "create"
-      model: "school"
-      save_as: "sec_school"
-      values:
-        name: "SEC School"
-        code: "SECSC"
-        grade_type_id: "REC: sec_grade_type.id"
-
-    - step: "Create the academic year"
-      action: "create"
-      model: "school_academic_year"
-      save_as: "sec_academic_year"
-      values:
-        name: "SEC Academic Year"
-        code: "SECAY"
-        date_start: 2026-07-01
-        date_end: 2027-06-30
-
-    - step: "Create the student contact"
-      action: "create"
-      model: "res.partner"
-      save_as: "sec_contact"
-      values:
-        name: "SEC Contact"
-
-    - step: "Create the student"
-      action: "create"
-      model: "school_student"
-      save_as: "sec_student"
-      values:
-        name: "SEC Student"
-        code: "SECST"
-        contact_id: "REC: sec_contact.id"
-        school_id: "REC: sec_school.id"
-
-    - step: "Create the analytic account for the funding source"
-      action: "create"
-      model: "account.analytic.account"
-      save_as: "sec_analytic"
-      values:
-        name: "SEC Analytic"
-
-    - step: "Create the funding source"
-      action: "create"
-      model: "school_scholarship_funding_source"
-      save_as: "sec_funding_source"
-      values:
-        name: "SEC Funding Source"
-        code: "SECFS"
-        analytic_account_id: "REC: sec_analytic.id"
-
-    - step: "Create the journal"
-      action: "create"
-      model: "account.journal"
-      save_as: "sec_journal"
-      values:
-        name: "SEC Journal"
-        code: "SECJ"
-        type: "sale"
-
-    - step: "Get the account.account.type Income reference"
-      action: "ref"
-      xml_id: "account.data_account_type_revenue"
-      save_as: "sec_account_type_income"
-
-    - step: "Create the discount (final) account"
-      action: "create"
-      model: "account.account"
-      save_as: "sec_discount_account"
-      values:
-        name: "SEC Discount Account"
-        code: "SECDA"
-        user_type_id: "REC: sec_account_type_income.id"
-        reconcile: false
-
-    - step: "Get the account.account.type Receivable reference"
-      action: "ref"
-      xml_id: "account.data_account_type_receivable"
-      save_as: "sec_account_type_receivable"
-
-    - step: "Create the receivable account"
-      action: "create"
-      model: "account.account"
-      save_as: "sec_receivable_account"
-      values:
-        name: "SEC Receivable Account"
-        code: "SECRA"
-        user_type_id: "REC: sec_account_type_receivable.id"
-        reconcile: true
-
-    - step: "Create the scholarship type"
-      action: "create"
-      model: "school_scholarship_type"
-      save_as: "sec_type"
-      values:
-        name: "SEC Type"
-        code: "SECTY"
-        deduction_journal_id: "REC: sec_journal.id"
-        discount_account_id: "REC: sec_discount_account.id"
-
-    - step: "Create the scholarship program"
-      action: "create"
-      model: "school_scholarship_program"
-      save_as: "sec_program"
-      values:
-        name: "SEC Program"
-        code: "SECPRG"
-        type_id: "REC: sec_type.id"
-        school_id: "REC: sec_school.id"
-        academic_year_id: "REC: sec_academic_year.id"
-        funding_source_ids: [[6, 0, ["REC: sec_funding_source.id"]]]
-        deduction_journal_id: "REC: sec_journal.id"
-        discount_account_id: "REC: sec_discount_account.id"
-
-    - step: "Create the award, owned by admin"
-      action: "create"
-      model: "school_scholarship_award"
-      save_as: "sec_award"
-      values:
-        program_id: "REC: sec_program.id"
-        student_id: "REC: sec_student.id"
-        date_start: 2026-07-01
-        date_end: 2026-12-31
-        user_id: "REC: sec_admin.id"
-
-    - step: "Create the deduction, owned by admin"
-      action: "create"
-      model: "school_scholarship_deduction"
-      save_as: "sec_deduction"
-      values:
-        award_id: "REC: sec_award.id"
-        date: 2026-03-01
-        journal_id: "REC: sec_journal.id"
-        receivable_account_id: "REC: sec_receivable_account.id"
-        user_id: "REC: sec_admin.id"
+# No shared `setup:` block here on purpose. Every scenario in this file
+# runs inside the SAME database transaction (odoo-yaml-test replays
+# `setup:` in full for every scenario, without a savepoint -- see
+# odoo-development-unit-test T-01), so a fixture shared across
+# scenarios via `setup:` would recreate the same unique codes on every
+# replay and fail with "Duplicate code" from the second scenario
+# onward. Instead, each scenario that needs a Deduction to point
+# `deduction_id` at builds its own self-contained fixture chain with a
+# scenario-unique code prefix -- the same pattern already used by
+# test_data_school_scholarship_deduction_recognition.yaml (r1_/r2_)
+# in this module.
 
 scenarios:
-  - name:
-      "Recognition workflow and data ownership groups form their own
-      ladders"
+  - name: "Recognition workflow and data ownership groups form their own ladders"
     steps:
       - step: "Get school_scholarship_deduction_recognition_viewer_group"
         action: "ref"
@@ -215,9 +68,7 @@ scenarios:
             expected_records:
               - "REC: recognition_viewer_group"
 
-      - step:
-          "Assert validator group's category, name, and implied user
-          group"
+      - step: "Assert validator group's category, name, and implied user group"
         action: "assert"
         target: "recognition_validator_group"
         asserts:
@@ -244,9 +95,7 @@ scenarios:
             type: "value"
             expected: "Company"
 
-      - step:
-          "Assert company_child group's category, name, and implied
-          company group"
+      - step: "Assert company_child group's category, name, and implied company group"
         action: "assert"
         target: "recognition_company_child_group"
         asserts:
@@ -262,9 +111,7 @@ scenarios:
             expected_records:
               - "REC: recognition_company_group"
 
-      - step:
-          "Assert all group's category, name, and implied
-          company_child group"
+      - step: "Assert all group's category, name, and implied company_child group"
         action: "assert"
         target: "recognition_all_group"
         asserts:
@@ -295,9 +142,218 @@ scenarios:
             expected_xml_id: "ssi_school_scholarship_deduction.school_scholarship_deduction_recognition_user_group"
 
   - name:
-      "A user holding only the Recognition User + Company groups can
-      create a Recognition"
+      "A user holding only the Recognition User + Company groups can create a
+      Recognition"
     steps:
+      # ── Self-contained fixture chain (prefix SEC3) ─────────────────
+      - step: "Create the grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "sec3_grade_type"
+        values:
+          name: "SEC3 Grade Type"
+          code: "SEC3GT"
+
+      - step: "Create the school"
+        action: "create"
+        model: "school"
+        save_as: "sec3_school"
+        values:
+          name: "SEC3 School"
+          code: "SEC3SC"
+          grade_type_id: "REC: sec3_grade_type.id"
+
+      - step: "Create the academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "sec3_academic_year"
+        values:
+          name: "SEC3 Academic Year"
+          code: "SEC3AY"
+          date_start: 2026-07-01
+          date_end: 2027-06-30
+
+      - step: "Create the academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "sec3_academic_term"
+        values:
+          name: "SEC3 Term"
+          code: "SEC3TM"
+          date_start: 2026-07-01
+          date_end: 2026-12-31
+          year_id: "REC: sec3_academic_year.id"
+
+      - step: "Create the grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "sec3_grade"
+        values:
+          name: "SEC3 Grade"
+          code: "SEC3GR"
+          type_id: "REC: sec3_grade_type.id"
+
+      - step: "Create the grade class"
+        action: "create"
+        model: "school_grade_class"
+        save_as: "sec3_grade_class"
+        values:
+          name: "SEC3 Class"
+          code: "SEC3CL"
+          school_id: "REC: sec3_school.id"
+          grade_id: "REC: sec3_grade.id"
+
+      - step: "Create the student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "sec3_contact"
+        values:
+          name: "SEC3 Contact"
+
+      - step: "Create the student"
+        action: "create"
+        model: "school_student"
+        save_as: "sec3_student"
+        values:
+          name: "SEC3 Student"
+          code: "SEC3ST"
+          contact_id: "REC: sec3_contact.id"
+          school_id: "REC: sec3_school.id"
+
+      - step: "Create the enrollment"
+        action: "create"
+        model: "school_enrollment"
+        save_as: "sec3_enrollment"
+        values:
+          academic_year_id: "REC: sec3_academic_year.id"
+          academic_term_id: "REC: sec3_academic_term.id"
+          school_id: "REC: sec3_school.id"
+          grade_id: "REC: sec3_grade.id"
+          grade_class_id: "REC: sec3_grade_class.id"
+          student_id: "REC: sec3_student.id"
+
+      - step: "Create the analytic account for the funding source"
+        action: "create"
+        model: "account.analytic.account"
+        save_as: "sec3_analytic"
+        values:
+          name: "SEC3 Analytic"
+
+      - step: "Create the funding source"
+        action: "create"
+        model: "school_scholarship_funding_source"
+        save_as: "sec3_funding_source"
+        values:
+          name: "SEC3 Funding Source"
+          code: "SEC3FS"
+          analytic_account_id: "REC: sec3_analytic.id"
+
+      - step: "Create the product covered by the program's scope line"
+        action: "create"
+        model: "product.product"
+        save_as: "sec3_product"
+        values:
+          name: "SEC3 Product"
+          type: "service"
+
+      - step: "Create the journal"
+        action: "create"
+        model: "account.journal"
+        save_as: "sec3_journal"
+        values:
+          name: "SEC3 Journal"
+          code: "SEC3J"
+          type: "sale"
+
+      - step: "Get the account.account.type Income reference"
+        action: "ref"
+        xml_id: "account.data_account_type_revenue"
+        save_as: "sec3_account_type_income"
+
+      - step: "Create the discount (final) account"
+        action: "create"
+        model: "account.account"
+        save_as: "sec3_discount_account"
+        values:
+          name: "SEC3 Discount Account"
+          code: "SEC3DA"
+          user_type_id: "REC: sec3_account_type_income.id"
+          reconcile: false
+
+      - step: "Get the account.account.type Receivable reference"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "sec3_account_type_receivable"
+
+      - step: "Create the receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "sec3_receivable_account"
+        values:
+          name: "SEC3 Receivable Account"
+          code: "SEC3RA"
+          user_type_id: "REC: sec3_account_type_receivable.id"
+          reconcile: true
+
+      - step: "Create the scholarship type"
+        action: "create"
+        model: "school_scholarship_type"
+        save_as: "sec3_type"
+        values:
+          name: "SEC3 Type"
+          code: "SEC3TY"
+          deduction_journal_id: "REC: sec3_journal.id"
+          discount_account_id: "REC: sec3_discount_account.id"
+
+      - step: "Create the scholarship program"
+        action: "create"
+        model: "school_scholarship_program"
+        save_as: "sec3_program"
+        values:
+          name: "SEC3 Program"
+          code: "SEC3PRG"
+          type_id: "REC: sec3_type.id"
+          school_id: "REC: sec3_school.id"
+          academic_year_id: "REC: sec3_academic_year.id"
+          funding_source_ids: [[6, 0, ["REC: sec3_funding_source.id"]]]
+          deduction_journal_id: "REC: sec3_journal.id"
+          discount_account_id: "REC: sec3_discount_account.id"
+          scope_ids:
+            - - 0
+              - 0
+              - scope_basis: "product"
+                product_id: "REC: sec3_product.id"
+                benefit_type: "cash"
+                computation: "fixed"
+                percentage: 0.0
+                amount_fixed: 100000.0
+
+      - step: "Create the award, owned by admin, immediate recognition"
+        action: "create"
+        model: "school_scholarship_award"
+        save_as: "sec3_award"
+        values:
+          program_id: "REC: sec3_program.id"
+          student_id: "REC: sec3_student.id"
+          enrollment_id: "REC: sec3_enrollment.id"
+          date_start: 2026-01-01
+          date_end: 2026-12-31
+          user_id: "REF: base.user_admin"
+
+      - step:
+          "Create the deduction, owned by admin, Date after the Award's Start Date so it
+          stays Immediate (no Deferred Account needed)"
+        action: "create"
+        model: "school_scholarship_deduction"
+        save_as: "sec3_deduction"
+        values:
+          award_id: "REC: sec3_award.id"
+          date: 2026-03-01
+          journal_id: "REC: sec3_journal.id"
+          receivable_account_id: "REC: sec3_receivable_account.id"
+          user_id: "REF: base.user_admin"
+
+      # ── Scenario body ────────────────────────────────────────────
       - step: "Create a user restricted to the Recognition groups"
         action: "create"
         model: "res.users"
@@ -320,10 +376,10 @@ scenarios:
         save_as: "recognition_by_scoped_user"
         as_user: "recognition_scoped_user"
         values:
-          deduction_id: "REC: sec_deduction.id"
+          deduction_id: "REC: sec3_deduction.id"
           date: 2026-03-15
           amount: 100000.0
-          journal_id: "REC: sec_journal.id"
+          journal_id: "REC: sec3_journal.id"
 
       - step: "Assert the Recognition was created in draft"
         action: "assert"
@@ -335,6 +391,215 @@ scenarios:
 
   - name: "A user holding only base.group_user cannot create a Recognition"
     steps:
+      # ── Self-contained fixture chain (prefix SEC4) ─────────────────
+      - step: "Create the grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "sec4_grade_type"
+        values:
+          name: "SEC4 Grade Type"
+          code: "SEC4GT"
+
+      - step: "Create the school"
+        action: "create"
+        model: "school"
+        save_as: "sec4_school"
+        values:
+          name: "SEC4 School"
+          code: "SEC4SC"
+          grade_type_id: "REC: sec4_grade_type.id"
+
+      - step: "Create the academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "sec4_academic_year"
+        values:
+          name: "SEC4 Academic Year"
+          code: "SEC4AY"
+          date_start: 2026-07-01
+          date_end: 2027-06-30
+
+      - step: "Create the academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "sec4_academic_term"
+        values:
+          name: "SEC4 Term"
+          code: "SEC4TM"
+          date_start: 2026-07-01
+          date_end: 2026-12-31
+          year_id: "REC: sec4_academic_year.id"
+
+      - step: "Create the grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "sec4_grade"
+        values:
+          name: "SEC4 Grade"
+          code: "SEC4GR"
+          type_id: "REC: sec4_grade_type.id"
+
+      - step: "Create the grade class"
+        action: "create"
+        model: "school_grade_class"
+        save_as: "sec4_grade_class"
+        values:
+          name: "SEC4 Class"
+          code: "SEC4CL"
+          school_id: "REC: sec4_school.id"
+          grade_id: "REC: sec4_grade.id"
+
+      - step: "Create the student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "sec4_contact"
+        values:
+          name: "SEC4 Contact"
+
+      - step: "Create the student"
+        action: "create"
+        model: "school_student"
+        save_as: "sec4_student"
+        values:
+          name: "SEC4 Student"
+          code: "SEC4ST"
+          contact_id: "REC: sec4_contact.id"
+          school_id: "REC: sec4_school.id"
+
+      - step: "Create the enrollment"
+        action: "create"
+        model: "school_enrollment"
+        save_as: "sec4_enrollment"
+        values:
+          academic_year_id: "REC: sec4_academic_year.id"
+          academic_term_id: "REC: sec4_academic_term.id"
+          school_id: "REC: sec4_school.id"
+          grade_id: "REC: sec4_grade.id"
+          grade_class_id: "REC: sec4_grade_class.id"
+          student_id: "REC: sec4_student.id"
+
+      - step: "Create the analytic account for the funding source"
+        action: "create"
+        model: "account.analytic.account"
+        save_as: "sec4_analytic"
+        values:
+          name: "SEC4 Analytic"
+
+      - step: "Create the funding source"
+        action: "create"
+        model: "school_scholarship_funding_source"
+        save_as: "sec4_funding_source"
+        values:
+          name: "SEC4 Funding Source"
+          code: "SEC4FS"
+          analytic_account_id: "REC: sec4_analytic.id"
+
+      - step: "Create the product covered by the program's scope line"
+        action: "create"
+        model: "product.product"
+        save_as: "sec4_product"
+        values:
+          name: "SEC4 Product"
+          type: "service"
+
+      - step: "Create the journal"
+        action: "create"
+        model: "account.journal"
+        save_as: "sec4_journal"
+        values:
+          name: "SEC4 Journal"
+          code: "SEC4J"
+          type: "sale"
+
+      - step: "Get the account.account.type Income reference"
+        action: "ref"
+        xml_id: "account.data_account_type_revenue"
+        save_as: "sec4_account_type_income"
+
+      - step: "Create the discount (final) account"
+        action: "create"
+        model: "account.account"
+        save_as: "sec4_discount_account"
+        values:
+          name: "SEC4 Discount Account"
+          code: "SEC4DA"
+          user_type_id: "REC: sec4_account_type_income.id"
+          reconcile: false
+
+      - step: "Get the account.account.type Receivable reference"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "sec4_account_type_receivable"
+
+      - step: "Create the receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "sec4_receivable_account"
+        values:
+          name: "SEC4 Receivable Account"
+          code: "SEC4RA"
+          user_type_id: "REC: sec4_account_type_receivable.id"
+          reconcile: true
+
+      - step: "Create the scholarship type"
+        action: "create"
+        model: "school_scholarship_type"
+        save_as: "sec4_type"
+        values:
+          name: "SEC4 Type"
+          code: "SEC4TY"
+          deduction_journal_id: "REC: sec4_journal.id"
+          discount_account_id: "REC: sec4_discount_account.id"
+
+      - step: "Create the scholarship program"
+        action: "create"
+        model: "school_scholarship_program"
+        save_as: "sec4_program"
+        values:
+          name: "SEC4 Program"
+          code: "SEC4PRG"
+          type_id: "REC: sec4_type.id"
+          school_id: "REC: sec4_school.id"
+          academic_year_id: "REC: sec4_academic_year.id"
+          funding_source_ids: [[6, 0, ["REC: sec4_funding_source.id"]]]
+          deduction_journal_id: "REC: sec4_journal.id"
+          discount_account_id: "REC: sec4_discount_account.id"
+          scope_ids:
+            - - 0
+              - 0
+              - scope_basis: "product"
+                product_id: "REC: sec4_product.id"
+                benefit_type: "cash"
+                computation: "fixed"
+                percentage: 0.0
+                amount_fixed: 100000.0
+
+      - step: "Create the award, owned by admin, immediate recognition"
+        action: "create"
+        model: "school_scholarship_award"
+        save_as: "sec4_award"
+        values:
+          program_id: "REC: sec4_program.id"
+          student_id: "REC: sec4_student.id"
+          enrollment_id: "REC: sec4_enrollment.id"
+          date_start: 2026-01-01
+          date_end: 2026-12-31
+          user_id: "REF: base.user_admin"
+
+      - step:
+          "Create the deduction, owned by admin, Date after the Award's Start Date so it
+          stays Immediate (no Deferred Account needed)"
+        action: "create"
+        model: "school_scholarship_deduction"
+        save_as: "sec4_deduction"
+        values:
+          award_id: "REC: sec4_award.id"
+          date: 2026-03-01
+          journal_id: "REC: sec4_journal.id"
+          receivable_account_id: "REC: sec4_receivable_account.id"
+          user_id: "REF: base.user_admin"
+
+      # ── Scenario body ────────────────────────────────────────────
       - step: "Create a plain internal user"
         action: "create"
         model: "res.users"
@@ -354,15 +619,224 @@ scenarios:
         expect_error:
           type: "AccessError"
         values:
-          deduction_id: "REC: sec_deduction.id"
+          deduction_id: "REC: sec4_deduction.id"
           date: 2026-03-15
           amount: 100000.0
-          journal_id: "REC: sec_journal.id"
+          journal_id: "REC: sec4_journal.id"
 
   - name:
-      "A user holding only the Deduction's own User + Company groups
-      (not Recognition's) cannot create a Recognition"
+      "A user holding only the Deduction's own User + Company groups (not Recognition's)
+      cannot create a Recognition"
     steps:
+      # ── Self-contained fixture chain (prefix SEC5) ─────────────────
+      - step: "Create the grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "sec5_grade_type"
+        values:
+          name: "SEC5 Grade Type"
+          code: "SEC5GT"
+
+      - step: "Create the school"
+        action: "create"
+        model: "school"
+        save_as: "sec5_school"
+        values:
+          name: "SEC5 School"
+          code: "SEC5SC"
+          grade_type_id: "REC: sec5_grade_type.id"
+
+      - step: "Create the academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "sec5_academic_year"
+        values:
+          name: "SEC5 Academic Year"
+          code: "SEC5AY"
+          date_start: 2026-07-01
+          date_end: 2027-06-30
+
+      - step: "Create the academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "sec5_academic_term"
+        values:
+          name: "SEC5 Term"
+          code: "SEC5TM"
+          date_start: 2026-07-01
+          date_end: 2026-12-31
+          year_id: "REC: sec5_academic_year.id"
+
+      - step: "Create the grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "sec5_grade"
+        values:
+          name: "SEC5 Grade"
+          code: "SEC5GR"
+          type_id: "REC: sec5_grade_type.id"
+
+      - step: "Create the grade class"
+        action: "create"
+        model: "school_grade_class"
+        save_as: "sec5_grade_class"
+        values:
+          name: "SEC5 Class"
+          code: "SEC5CL"
+          school_id: "REC: sec5_school.id"
+          grade_id: "REC: sec5_grade.id"
+
+      - step: "Create the student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "sec5_contact"
+        values:
+          name: "SEC5 Contact"
+
+      - step: "Create the student"
+        action: "create"
+        model: "school_student"
+        save_as: "sec5_student"
+        values:
+          name: "SEC5 Student"
+          code: "SEC5ST"
+          contact_id: "REC: sec5_contact.id"
+          school_id: "REC: sec5_school.id"
+
+      - step: "Create the enrollment"
+        action: "create"
+        model: "school_enrollment"
+        save_as: "sec5_enrollment"
+        values:
+          academic_year_id: "REC: sec5_academic_year.id"
+          academic_term_id: "REC: sec5_academic_term.id"
+          school_id: "REC: sec5_school.id"
+          grade_id: "REC: sec5_grade.id"
+          grade_class_id: "REC: sec5_grade_class.id"
+          student_id: "REC: sec5_student.id"
+
+      - step: "Create the analytic account for the funding source"
+        action: "create"
+        model: "account.analytic.account"
+        save_as: "sec5_analytic"
+        values:
+          name: "SEC5 Analytic"
+
+      - step: "Create the funding source"
+        action: "create"
+        model: "school_scholarship_funding_source"
+        save_as: "sec5_funding_source"
+        values:
+          name: "SEC5 Funding Source"
+          code: "SEC5FS"
+          analytic_account_id: "REC: sec5_analytic.id"
+
+      - step: "Create the product covered by the program's scope line"
+        action: "create"
+        model: "product.product"
+        save_as: "sec5_product"
+        values:
+          name: "SEC5 Product"
+          type: "service"
+
+      - step: "Create the journal"
+        action: "create"
+        model: "account.journal"
+        save_as: "sec5_journal"
+        values:
+          name: "SEC5 Journal"
+          code: "SEC5J"
+          type: "sale"
+
+      - step: "Get the account.account.type Income reference"
+        action: "ref"
+        xml_id: "account.data_account_type_revenue"
+        save_as: "sec5_account_type_income"
+
+      - step: "Create the discount (final) account"
+        action: "create"
+        model: "account.account"
+        save_as: "sec5_discount_account"
+        values:
+          name: "SEC5 Discount Account"
+          code: "SEC5DA"
+          user_type_id: "REC: sec5_account_type_income.id"
+          reconcile: false
+
+      - step: "Get the account.account.type Receivable reference"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "sec5_account_type_receivable"
+
+      - step: "Create the receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "sec5_receivable_account"
+        values:
+          name: "SEC5 Receivable Account"
+          code: "SEC5RA"
+          user_type_id: "REC: sec5_account_type_receivable.id"
+          reconcile: true
+
+      - step: "Create the scholarship type"
+        action: "create"
+        model: "school_scholarship_type"
+        save_as: "sec5_type"
+        values:
+          name: "SEC5 Type"
+          code: "SEC5TY"
+          deduction_journal_id: "REC: sec5_journal.id"
+          discount_account_id: "REC: sec5_discount_account.id"
+
+      - step: "Create the scholarship program"
+        action: "create"
+        model: "school_scholarship_program"
+        save_as: "sec5_program"
+        values:
+          name: "SEC5 Program"
+          code: "SEC5PRG"
+          type_id: "REC: sec5_type.id"
+          school_id: "REC: sec5_school.id"
+          academic_year_id: "REC: sec5_academic_year.id"
+          funding_source_ids: [[6, 0, ["REC: sec5_funding_source.id"]]]
+          deduction_journal_id: "REC: sec5_journal.id"
+          discount_account_id: "REC: sec5_discount_account.id"
+          scope_ids:
+            - - 0
+              - 0
+              - scope_basis: "product"
+                product_id: "REC: sec5_product.id"
+                benefit_type: "cash"
+                computation: "fixed"
+                percentage: 0.0
+                amount_fixed: 100000.0
+
+      - step: "Create the award, owned by admin, immediate recognition"
+        action: "create"
+        model: "school_scholarship_award"
+        save_as: "sec5_award"
+        values:
+          program_id: "REC: sec5_program.id"
+          student_id: "REC: sec5_student.id"
+          enrollment_id: "REC: sec5_enrollment.id"
+          date_start: 2026-01-01
+          date_end: 2026-12-31
+          user_id: "REF: base.user_admin"
+
+      - step:
+          "Create the deduction, owned by admin, Date after the Award's Start Date so it
+          stays Immediate (no Deferred Account needed)"
+        action: "create"
+        model: "school_scholarship_deduction"
+        save_as: "sec5_deduction"
+        values:
+          award_id: "REC: sec5_award.id"
+          date: 2026-03-01
+          journal_id: "REC: sec5_journal.id"
+          receivable_account_id: "REC: sec5_receivable_account.id"
+          user_id: "REF: base.user_admin"
+
+      # ── Scenario body ────────────────────────────────────────────
       - step: "Create a user restricted to the Deduction groups"
         action: "create"
         model: "res.users"
@@ -380,15 +854,15 @@ scenarios:
                   ssi_school_scholarship_deduction.school_scholarship_deduction_company_group"
 
       - step:
-          "Deduction-scoped user cannot create a Recognition -- this is
-          the authorization separation this module change introduces"
+          "Deduction-scoped user cannot create a Recognition -- this is the
+          authorization separation this module change introduces"
         action: "create"
         model: "school_scholarship_deduction_recognition"
         as_user: "deduction_scoped_user"
         expect_error:
           type: "AccessError"
         values:
-          deduction_id: "REC: sec_deduction.id"
+          deduction_id: "REC: sec5_deduction.id"
           date: 2026-03-15
           amount: 100000.0
-          journal_id: "REC: sec_journal.id"
+          journal_id: "REC: sec5_journal.id"

--- a/ssi_school_scholarship_deduction/tests/test_data_school_scholarship_deduction_recognition_security.yaml
+++ b/ssi_school_scholarship_deduction/tests/test_data_school_scholarship_deduction_recognition_security.yaml
@@ -1,0 +1,394 @@
+options:
+  auto_refresh: true
+
+# Shared fixture: one Deduction, owned by admin, replayed fresh before
+# every scenario below. Deliberately has no Lines -- creating a
+# Recognition only needs an existing Deduction id, not a fully worked
+# Deduction -- so the chain stops at the minimum required to satisfy
+# Award/Program/Deduction's own required fields.
+setup:
+  steps:
+    - step: "Get the admin user reference"
+      action: "ref"
+      xml_id: "base.user_admin"
+      save_as: "sec_admin"
+
+    - step: "Create the grade type"
+      action: "create"
+      model: "school_grade_type"
+      save_as: "sec_grade_type"
+      values:
+        name: "SEC Grade Type"
+        code: "SECGT"
+
+    - step: "Create the school"
+      action: "create"
+      model: "school"
+      save_as: "sec_school"
+      values:
+        name: "SEC School"
+        code: "SECSC"
+        grade_type_id: "REC: sec_grade_type.id"
+
+    - step: "Create the academic year"
+      action: "create"
+      model: "school_academic_year"
+      save_as: "sec_academic_year"
+      values:
+        name: "SEC Academic Year"
+        code: "SECAY"
+        date_start: 2026-07-01
+        date_end: 2027-06-30
+
+    - step: "Create the student contact"
+      action: "create"
+      model: "res.partner"
+      save_as: "sec_contact"
+      values:
+        name: "SEC Contact"
+
+    - step: "Create the student"
+      action: "create"
+      model: "school_student"
+      save_as: "sec_student"
+      values:
+        name: "SEC Student"
+        code: "SECST"
+        contact_id: "REC: sec_contact.id"
+        school_id: "REC: sec_school.id"
+
+    - step: "Create the analytic account for the funding source"
+      action: "create"
+      model: "account.analytic.account"
+      save_as: "sec_analytic"
+      values:
+        name: "SEC Analytic"
+
+    - step: "Create the funding source"
+      action: "create"
+      model: "school_scholarship_funding_source"
+      save_as: "sec_funding_source"
+      values:
+        name: "SEC Funding Source"
+        code: "SECFS"
+        analytic_account_id: "REC: sec_analytic.id"
+
+    - step: "Create the journal"
+      action: "create"
+      model: "account.journal"
+      save_as: "sec_journal"
+      values:
+        name: "SEC Journal"
+        code: "SECJ"
+        type: "sale"
+
+    - step: "Get the account.account.type Income reference"
+      action: "ref"
+      xml_id: "account.data_account_type_revenue"
+      save_as: "sec_account_type_income"
+
+    - step: "Create the discount (final) account"
+      action: "create"
+      model: "account.account"
+      save_as: "sec_discount_account"
+      values:
+        name: "SEC Discount Account"
+        code: "SECDA"
+        user_type_id: "REC: sec_account_type_income.id"
+        reconcile: false
+
+    - step: "Get the account.account.type Receivable reference"
+      action: "ref"
+      xml_id: "account.data_account_type_receivable"
+      save_as: "sec_account_type_receivable"
+
+    - step: "Create the receivable account"
+      action: "create"
+      model: "account.account"
+      save_as: "sec_receivable_account"
+      values:
+        name: "SEC Receivable Account"
+        code: "SECRA"
+        user_type_id: "REC: sec_account_type_receivable.id"
+        reconcile: true
+
+    - step: "Create the scholarship type"
+      action: "create"
+      model: "school_scholarship_type"
+      save_as: "sec_type"
+      values:
+        name: "SEC Type"
+        code: "SECTY"
+        deduction_journal_id: "REC: sec_journal.id"
+        discount_account_id: "REC: sec_discount_account.id"
+
+    - step: "Create the scholarship program"
+      action: "create"
+      model: "school_scholarship_program"
+      save_as: "sec_program"
+      values:
+        name: "SEC Program"
+        code: "SECPRG"
+        type_id: "REC: sec_type.id"
+        school_id: "REC: sec_school.id"
+        academic_year_id: "REC: sec_academic_year.id"
+        funding_source_ids: [[6, 0, ["REC: sec_funding_source.id"]]]
+        deduction_journal_id: "REC: sec_journal.id"
+        discount_account_id: "REC: sec_discount_account.id"
+
+    - step: "Create the award, owned by admin"
+      action: "create"
+      model: "school_scholarship_award"
+      save_as: "sec_award"
+      values:
+        program_id: "REC: sec_program.id"
+        student_id: "REC: sec_student.id"
+        date_start: 2026-07-01
+        date_end: 2026-12-31
+        user_id: "REC: sec_admin.id"
+
+    - step: "Create the deduction, owned by admin"
+      action: "create"
+      model: "school_scholarship_deduction"
+      save_as: "sec_deduction"
+      values:
+        award_id: "REC: sec_award.id"
+        date: 2026-03-01
+        journal_id: "REC: sec_journal.id"
+        receivable_account_id: "REC: sec_receivable_account.id"
+        user_id: "REC: sec_admin.id"
+
+scenarios:
+  - name:
+      "Recognition workflow and data ownership groups form their own
+      ladders"
+    steps:
+      - step: "Get school_scholarship_deduction_recognition_viewer_group"
+        action: "ref"
+        xml_id: "ssi_school_scholarship_deduction.school_scholarship_deduction_recognition_viewer_group"
+        save_as: "recognition_viewer_group"
+      - step: "Get school_scholarship_deduction_recognition_user_group"
+        action: "ref"
+        xml_id: "ssi_school_scholarship_deduction.school_scholarship_deduction_recognition_user_group"
+        save_as: "recognition_user_group"
+      - step: "Get school_scholarship_deduction_recognition_validator_group"
+        action: "ref"
+        xml_id: "ssi_school_scholarship_deduction.school_scholarship_deduction_recognition_validator_group"
+        save_as: "recognition_validator_group"
+      - step: "Get school_scholarship_deduction_recognition_company_group"
+        action: "ref"
+        xml_id: "ssi_school_scholarship_deduction.school_scholarship_deduction_recognition_company_group"
+        save_as: "recognition_company_group"
+      - step: "Get school_scholarship_deduction_recognition_company_child_group"
+        action: "ref"
+        xml_id: "ssi_school_scholarship_deduction.school_scholarship_deduction_recognition_company_child_group"
+        save_as: "recognition_company_child_group"
+      - step: "Get school_scholarship_deduction_recognition_all_group"
+        action: "ref"
+        xml_id: "ssi_school_scholarship_deduction.school_scholarship_deduction_recognition_all_group"
+        save_as: "recognition_all_group"
+
+      - step: "Assert viewer group's category and literal name"
+        action: "assert"
+        target: "recognition_viewer_group"
+        asserts:
+          category_id:
+            type: "m2o"
+            expected_xml_id: "ssi_school_scholarship_deduction.school_scholarship_deduction_recognition_workflow_module_category"
+          name:
+            type: "value"
+            expected: "Viewer"
+
+      - step: "Assert user group's category, name, and implied viewer group"
+        action: "assert"
+        target: "recognition_user_group"
+        asserts:
+          category_id:
+            type: "m2o"
+            expected_xml_id: "ssi_school_scholarship_deduction.school_scholarship_deduction_recognition_workflow_module_category"
+          name:
+            type: "value"
+            expected: "User"
+          implied_ids:
+            type: "m2m"
+            check: "contains"
+            expected_records:
+              - "REC: recognition_viewer_group"
+
+      - step:
+          "Assert validator group's category, name, and implied user
+          group"
+        action: "assert"
+        target: "recognition_validator_group"
+        asserts:
+          category_id:
+            type: "m2o"
+            expected_xml_id: "ssi_school_scholarship_deduction.school_scholarship_deduction_recognition_workflow_module_category"
+          name:
+            type: "value"
+            expected: "Validator"
+          implied_ids:
+            type: "m2m"
+            check: "contains"
+            expected_records:
+              - "REC: recognition_user_group"
+
+      - step: "Assert company group's category and literal name"
+        action: "assert"
+        target: "recognition_company_group"
+        asserts:
+          category_id:
+            type: "m2o"
+            expected_xml_id: "ssi_school_scholarship_deduction.school_scholarship_deduction_recognition_data_ownership_module_category"
+          name:
+            type: "value"
+            expected: "Company"
+
+      - step:
+          "Assert company_child group's category, name, and implied
+          company group"
+        action: "assert"
+        target: "recognition_company_child_group"
+        asserts:
+          category_id:
+            type: "m2o"
+            expected_xml_id: "ssi_school_scholarship_deduction.school_scholarship_deduction_recognition_data_ownership_module_category"
+          name:
+            type: "value"
+            expected: "Company and All Child Companies"
+          implied_ids:
+            type: "m2m"
+            check: "contains"
+            expected_records:
+              - "REC: recognition_company_group"
+
+      - step:
+          "Assert all group's category, name, and implied
+          company_child group"
+        action: "assert"
+        target: "recognition_all_group"
+        asserts:
+          category_id:
+            type: "m2o"
+            expected_xml_id: "ssi_school_scholarship_deduction.school_scholarship_deduction_recognition_data_ownership_module_category"
+          name:
+            type: "value"
+            expected: "All"
+          implied_ids:
+            type: "m2m"
+            check: "contains"
+            expected_records:
+              - "REC: recognition_company_child_group"
+
+  - name: "ACL for the recognition model points at its own User group"
+    steps:
+      - step: "Get the school_scholarship_deduction_recognition_user_access ACL"
+        action: "ref"
+        xml_id: "ssi_school_scholarship_deduction.school_scholarship_deduction_recognition_user_access"
+        save_as: "recognition_user_access"
+      - step: "Assert the ACL's group_id"
+        action: "assert"
+        target: "recognition_user_access"
+        asserts:
+          group_id:
+            type: "m2o"
+            expected_xml_id: "ssi_school_scholarship_deduction.school_scholarship_deduction_recognition_user_group"
+
+  - name:
+      "A user holding only the Recognition User + Company groups can
+      create a Recognition"
+    steps:
+      - step: "Create a user restricted to the Recognition groups"
+        action: "create"
+        model: "res.users"
+        save_as: "recognition_scoped_user"
+        values:
+          name: "SEC Recognition Scoped User"
+          login: "sec_recognition_scoped_user@example.com"
+          groups_id:
+            - - 6
+              - 0
+              - - "REF: base.group_user"
+                - "REF:
+                  ssi_school_scholarship_deduction.school_scholarship_deduction_recognition_user_group"
+                - "REF:
+                  ssi_school_scholarship_deduction.school_scholarship_deduction_recognition_company_group"
+
+      - step: "Recognition-scoped user creates a Recognition"
+        action: "create"
+        model: "school_scholarship_deduction_recognition"
+        save_as: "recognition_by_scoped_user"
+        as_user: "recognition_scoped_user"
+        values:
+          deduction_id: "REC: sec_deduction.id"
+          date: 2026-03-15
+          amount: 100000.0
+          journal_id: "REC: sec_journal.id"
+
+      - step: "Assert the Recognition was created in draft"
+        action: "assert"
+        target: "recognition_by_scoped_user"
+        asserts:
+          state:
+            type: "value"
+            expected: "draft"
+
+  - name: "A user holding only base.group_user cannot create a Recognition"
+    steps:
+      - step: "Create a plain internal user"
+        action: "create"
+        model: "res.users"
+        save_as: "plain_internal_user"
+        values:
+          name: "SEC Plain Internal User"
+          login: "sec_plain_internal_user@example.com"
+          groups_id:
+            - - 6
+              - 0
+              - - "REF: base.group_user"
+
+      - step: "Plain internal user cannot create a Recognition"
+        action: "create"
+        model: "school_scholarship_deduction_recognition"
+        as_user: "plain_internal_user"
+        expect_error:
+          type: "AccessError"
+        values:
+          deduction_id: "REC: sec_deduction.id"
+          date: 2026-03-15
+          amount: 100000.0
+          journal_id: "REC: sec_journal.id"
+
+  - name:
+      "A user holding only the Deduction's own User + Company groups
+      (not Recognition's) cannot create a Recognition"
+    steps:
+      - step: "Create a user restricted to the Deduction groups"
+        action: "create"
+        model: "res.users"
+        save_as: "deduction_scoped_user"
+        values:
+          name: "SEC Deduction Scoped User"
+          login: "sec_deduction_scoped_user@example.com"
+          groups_id:
+            - - 6
+              - 0
+              - - "REF: base.group_user"
+                - "REF:
+                  ssi_school_scholarship_deduction.school_scholarship_deduction_user_group"
+                - "REF:
+                  ssi_school_scholarship_deduction.school_scholarship_deduction_company_group"
+
+      - step:
+          "Deduction-scoped user cannot create a Recognition -- this is
+          the authorization separation this module change introduces"
+        action: "create"
+        model: "school_scholarship_deduction_recognition"
+        as_user: "deduction_scoped_user"
+        expect_error:
+          type: "AccessError"
+        values:
+          deduction_id: "REC: sec_deduction.id"
+          date: 2026-03-15
+          amount: 100000.0
+          journal_id: "REC: sec_journal.id"

--- a/ssi_school_scholarship_deduction/tests/test_school_scholarship_deduction_recognition_security.py
+++ b/ssi_school_scholarship_deduction/tests/test_school_scholarship_deduction_recognition_security.py
@@ -1,0 +1,21 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestSchoolScholarshipDeductionRecognitionSecurity(YamlTransactionCase):
+    """Scenario tests for the ``school_scholarship_deduction_recognition``
+    model's own group ladder, ACL, and authorization separation from
+    ``school_scholarship_deduction``.
+    """
+
+    def test_school_scholarship_deduction_recognition_security(self):
+        """Run the recognition group ladder and access control scenarios."""
+        self.run_yaml_scenario(
+            "test_data_school_scholarship_deduction_recognition_security.yaml"
+        )

--- a/ssi_school_scholarship_deduction/views/school_scholarship_deduction_recognition.xml
+++ b/ssi_school_scholarship_deduction/views/school_scholarship_deduction_recognition.xml
@@ -115,7 +115,7 @@
         name="Scholarship Deduction Recognitions"
         parent="ssi_school_scholarship.menu_school_scholarship"
         action="school_scholarship_deduction_recognition_action"
-        groups="school_scholarship_deduction_viewer_group"
+        groups="school_scholarship_deduction_recognition_viewer_group"
         sequence="21"
     />
 </odoo>

--- a/ssi_school_scholarship_deduction_operating_unit/security/res_groups/school_scholarship_deduction.xml
+++ b/ssi_school_scholarship_deduction_operating_unit/security/res_groups/school_scholarship_deduction.xml
@@ -12,4 +12,14 @@
         />
 </record>
 
+<record
+        id="ssi_school_scholarship_deduction.school_scholarship_deduction_company_group"
+        model="res.groups"
+    >
+    <field
+            name="implied_ids"
+            eval="[(4, ref('school_scholarship_deduction_operating_unit_group'))]"
+        />
+</record>
+
 </odoo>

--- a/ssi_school_scholarship_deduction_operating_unit/security/res_groups/school_scholarship_deduction_recognition.xml
+++ b/ssi_school_scholarship_deduction_operating_unit/security/res_groups/school_scholarship_deduction_recognition.xml
@@ -11,27 +11,21 @@
     <field name="name">Deduction Recognition Operating Unit</field>
     <field
             name="category_id"
-            ref="ssi_school_scholarship.school_scholarship_data_ownership_module_category"
+            ref="ssi_school_scholarship_deduction.school_scholarship_deduction_recognition_data_ownership_module_category"
         />
 </record>
 
-<!-- Both this module's Operating Unit groups are implied by the single
-     shared Company group from ssi_school_scholarship_deduction: this
-     record is deliberately the ONLY place that writes to it (rather than
-     one write per res_groups/*.xml file) since a second record sharing
-     the same external id is flagged as a duplicate by
-     oca-checks-odoo-module, even though Odoo itself would just apply it
-     as a second write. Loading this file after
-     school_scholarship_deduction.xml (see __manifest__.py data) is
-     what makes both groups already exist by the time this runs. -->
+<!-- Implied by the Deduction Recognition Company group (not the plain
+     Deduction Company group): recognition now owns its own workflow and
+     data-ownership group ladder, so its Operating Unit group is granted
+     through that ladder's Company group instead. -->
 <record
-        id="ssi_school_scholarship_deduction.school_scholarship_deduction_company_group"
+        id="ssi_school_scholarship_deduction.school_scholarship_deduction_recognition_company_group"
         model="res.groups"
     >
     <field
             name="implied_ids"
-            eval="[(4, ref('school_scholarship_deduction_operating_unit_group')),
-                   (4, ref('school_scholarship_deduction_recognition_operating_unit_group'))]"
+            eval="[(4, ref('school_scholarship_deduction_recognition_operating_unit_group'))]"
         />
 </record>
 

--- a/ssi_school_scholarship_deduction_operating_unit/tests/test_data_module_category.yaml
+++ b/ssi_school_scholarship_deduction_operating_unit/tests/test_data_module_category.yaml
@@ -18,8 +18,8 @@ scenarios:
             expected: "Operating Unit"
 
   - name:
-      "Deduction Recognition Operating Unit group points to its own recognition
-      data ownership category"
+      "Deduction Recognition Operating Unit group points to its own recognition data
+      ownership category"
     steps:
       - step:
           "Get school_scholarship_deduction_recognition_operating_unit_group by XML ID"
@@ -27,8 +27,8 @@ scenarios:
         xml_id: "ssi_school_scholarship_deduction_operating_unit.school_scholarship_deduction_recognition_operating_unit_group"
         save_as: "deduction_recognition_operating_unit_group"
       - step:
-          "Assert deduction_recognition_operating_unit_group points at the
-          recognition data ownership category"
+          "Assert deduction_recognition_operating_unit_group points at the recognition
+          data ownership category"
         action: "assert"
         target: "deduction_recognition_operating_unit_group"
         asserts:

--- a/ssi_school_scholarship_deduction_operating_unit/tests/test_data_module_category.yaml
+++ b/ssi_school_scholarship_deduction_operating_unit/tests/test_data_module_category.yaml
@@ -18,7 +18,8 @@ scenarios:
             expected: "Operating Unit"
 
   - name:
-      "Deduction Recognition Operating Unit group is intentionally left out of scope"
+      "Deduction Recognition Operating Unit group points to its own recognition
+      data ownership category"
     steps:
       - step:
           "Get school_scholarship_deduction_recognition_operating_unit_group by XML ID"
@@ -26,14 +27,14 @@ scenarios:
         xml_id: "ssi_school_scholarship_deduction_operating_unit.school_scholarship_deduction_recognition_operating_unit_group"
         save_as: "deduction_recognition_operating_unit_group"
       - step:
-          "Assert deduction_recognition_operating_unit_group still points at the old
-          shared data ownership category"
+          "Assert deduction_recognition_operating_unit_group points at the
+          recognition data ownership category"
         action: "assert"
         target: "deduction_recognition_operating_unit_group"
         asserts:
           category_id:
             type: "m2o"
-            expected_xml_id: "ssi_school_scholarship.school_scholarship_data_ownership_module_category"
+            expected_xml_id: "ssi_school_scholarship_deduction.school_scholarship_deduction_recognition_data_ownership_module_category"
 
   - name: "No res.groups still points at the shared workflow category"
     steps:
@@ -51,17 +52,9 @@ scenarios:
         save_as: "orphan_workflow_groups"
         expect_count: 0
 
-  - name:
-      "Only the out-of-scope Deduction Recognition group still points at the shared data
-      ownership category"
+  - name: "No res.groups still points at the shared data ownership category"
     steps:
-      - step: "Get deduction_recognition_operating_unit_group's id"
-        action: "ref"
-        xml_id: "ssi_school_scholarship_deduction_operating_unit.school_scholarship_deduction_recognition_operating_unit_group"
-        save_as: "recognition_ou_group"
-      - step:
-          "Search res.groups on the shared data ownership category, excluding the
-          deliberately out-of-scope Recognition group"
+      - step: "Search res.groups on the shared data ownership category"
         action: "search"
         model: "res.groups"
         domain:
@@ -72,7 +65,6 @@ scenarios:
               "REF:
               ssi_school_scholarship.school_scholarship_data_ownership_module_category",
             ],
-            ["id", "!=", "REC: recognition_ou_group.id"],
           ]
         save_as: "orphan_data_ownership_groups"
         expect_count: 0


### PR DESCRIPTION
## Summary

- `school_scholarship_deduction_recognition` now has its own workflow
  (Viewer/User/Validator) and data ownership
  (Company/Company and All Child Companies/All) group ladder, plus a
  matching pair of `ir.module.category` records, instead of piggybacking
  on `school_scholarship_deduction`'s groups for its own ACL, `ir.rule`
  and menu.
- `school_scholarship_deduction_recognition_operating_unit_group` (in
  `ssi_school_scholarship_deduction_operating_unit`) now lives under the
  new Recognition data ownership category and is implied by
  Recognition's own Company group instead of Deduction's.
- A `post-migrate.py` script copies each user's existing
  `school_scholarship_deduction_*` group membership onto the equivalent
  new `school_scholarship_deduction_recognition_*` group, so existing
  authorization keeps working after the upgrade without a manual
  re-grant.
- New YAML scenario tests cover the group ladder (category + implied_ids
  chain), the ACL, and — the actual point of this change — that a user
  with only Deduction's own User + Company groups can no longer create a
  Recognition document.

## Test plan

- [x] `verify-module.sh` on `ssi_school_scholarship_deduction` — `LOLOS: 0 ERROR`
- [x] `verify-module.sh` on `ssi_school_scholarship_deduction_operating_unit` — `LOLOS: 0 ERROR`
- [x] `validate-unit-test.sh` (`vs-head.sh`) on both modules — 0 new findings
- [ ] CI green

Closes open-synergy/ssi-school-scholarship#48