### PR TITLE
[UPD] ssi_school_scholarship_deduction: cabut invalidate_cache manual, uji onchange wizard

### DIFF
--- a/ssi_school_scholarship_deduction/tests/__init__.py
+++ b/ssi_school_scholarship_deduction/tests/__init__.py
@@ -10,4 +10,5 @@ from . import test_school_scholarship_deduction_recognition  # noqa: F401
 from . import test_school_scholarship_deduction_recognition_security  # noqa: F401
 from . import test_ui_school_scholarship_deduction_recognition  # noqa: F401
 from . import test_customer_invoice_scholarship_deduction  # noqa: F401
+from . import test_create_due_scholarship_recognition  # noqa: F401
 from . import test_module_category  # noqa: F401

--- a/ssi_school_scholarship_deduction/tests/test_create_due_scholarship_recognition.py
+++ b/ssi_school_scholarship_deduction/tests/test_create_due_scholarship_recognition.py
@@ -1,0 +1,26 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestCreateDueScholarshipRecognition(YamlTransactionCase):
+    """Onchange coverage for ``create_due_scholarship_recognition``.
+
+    The wizard's own workflow (releasing a due deduction, and the
+    empty-selection guard) is already covered in pure Python by
+    ``test_school_scholarship_deduction_recognition.py`` (P1: the
+    method under test returns an ``ir.actions.act_window`` dict /
+    raises directly, discarded by ``action: call`` in the YAML DSL --
+    odoo-development-unit-test references/python-escape-hatch.md).
+    This file adds the ``action: form`` scenario that method cannot:
+    ``onchange_deduction_ids`` only fires through the Form API.
+    """
+
+    def test_create_due_scholarship_recognition_onchange(self):
+        """Run the wizard's ``onchange_deduction_ids`` scenario."""
+        self.run_yaml_scenario("test_data_create_due_scholarship_recognition.yaml")

--- a/ssi_school_scholarship_deduction/tests/test_data_create_due_scholarship_recognition.yaml
+++ b/ssi_school_scholarship_deduction/tests/test_data_create_due_scholarship_recognition.yaml
@@ -1,0 +1,328 @@
+scenarios:
+  - name: "Create Due Scholarship Recognition - Onchange Deduction Ids"
+    steps:
+      # ── Shared fixture chain (prefix WF1) ────────────────────────
+      - step: "Create the grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "wf1_grade_type"
+        values:
+          name: "WF1 Grade Type"
+          code: "WF1GT"
+
+      - step: "Create the school"
+        action: "create"
+        model: "school"
+        save_as: "wf1_school"
+        values:
+          name: "WF1 School"
+          code: "WF1SC"
+          grade_type_id: "REC: wf1_grade_type.id"
+
+      - step: "Create the academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "wf1_academic_year"
+        values:
+          name: "WF1 Academic Year"
+          code: "WF1AY"
+          date_start: 2026-07-01
+          date_end: 2027-06-30
+
+      - step: "Create the academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "wf1_academic_term"
+        values:
+          name: "WF1 Term"
+          code: "WF1TM"
+          date_start: 2026-07-01
+          date_end: 2026-12-31
+          year_id: "REC: wf1_academic_year.id"
+
+      - step: "Create the grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "wf1_grade"
+        values:
+          name: "WF1 Grade"
+          code: "WF1GR"
+          type_id: "REC: wf1_grade_type.id"
+
+      - step: "Create the grade class"
+        action: "create"
+        model: "school_grade_class"
+        save_as: "wf1_grade_class"
+        values:
+          name: "WF1 Class"
+          code: "WF1CL"
+          school_id: "REC: wf1_school.id"
+          grade_id: "REC: wf1_grade.id"
+
+      - step: "Create the student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "wf1_contact"
+        values:
+          name: "WF1 Contact"
+
+      - step: "Create the student"
+        action: "create"
+        model: "school_student"
+        save_as: "wf1_student"
+        values:
+          name: "WF1 Student"
+          code: "WF1ST"
+          contact_id: "REC: wf1_contact.id"
+          school_id: "REC: wf1_school.id"
+
+      - step: "Create the enrollment"
+        action: "create"
+        model: "school_enrollment"
+        save_as: "wf1_enrollment"
+        values:
+          academic_year_id: "REC: wf1_academic_year.id"
+          academic_term_id: "REC: wf1_academic_term.id"
+          school_id: "REC: wf1_school.id"
+          grade_id: "REC: wf1_grade.id"
+          grade_class_id: "REC: wf1_grade_class.id"
+          student_id: "REC: wf1_student.id"
+
+      - step: "Create the analytic account for the funding source"
+        action: "create"
+        model: "account.analytic.account"
+        save_as: "wf1_analytic"
+        values:
+          name: "WF1 Analytic"
+
+      - step: "Create the funding source"
+        action: "create"
+        model: "school_scholarship_funding_source"
+        save_as: "wf1_funding_source"
+        values:
+          name: "WF1 Funding Source"
+          code: "WF1FS"
+          analytic_account_id: "REC: wf1_analytic.id"
+
+      - step: "Create the product covered by the benefit line"
+        action: "create"
+        model: "product.product"
+        save_as: "wf1_product"
+        values:
+          name: "WF1 Product"
+          type: "service"
+
+      - step: "Create the deduction journal"
+        action: "create"
+        model: "account.journal"
+        save_as: "wf1_journal"
+        values:
+          name: "WF1 Journal"
+          code: "JWF1"
+          type: "sale"
+
+      - step: "Get the account.account.type Income reference"
+        action: "ref"
+        xml_id: "account.data_account_type_revenue"
+        save_as: "wf1_account_type_income"
+
+      - step: "Get the account.account.type Receivable reference"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "wf1_account_type_receivable"
+
+      - step: "Get the account.account.type Current Assets reference"
+        action: "ref"
+        xml_id: "account.data_account_type_current_assets"
+        save_as: "wf1_account_type_asset"
+
+      - step: "Create the receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "wf1_receivable_account"
+        values:
+          name: "WF1 Receivable Account"
+          code: "WF1RA"
+          user_type_id: "REC: wf1_account_type_receivable.id"
+          reconcile: true
+
+      - step: "Create the discount account the deduction line posts to"
+        action: "create"
+        model: "account.account"
+        save_as: "wf1_discount_account"
+        values:
+          name: "WF1 Discount Account"
+          code: "WF1DA"
+          user_type_id: "REC: wf1_account_type_income.id"
+          reconcile: false
+
+      - step: "Create the deferred account the deduction line posts to"
+        action: "create"
+        model: "account.account"
+        save_as: "wf1_deferred_account"
+        values:
+          name: "WF1 Deferred Account"
+          code: "WF1FA"
+          user_type_id: "REC: wf1_account_type_asset.id"
+          reconcile: false
+
+      - step: "Create the scholarship type"
+        action: "create"
+        model: "school_scholarship_type"
+        save_as: "wf1_type"
+        values:
+          name: "WF1 Type"
+          code: "WF1TY"
+          deduction_journal_id: "REC: wf1_journal.id"
+          discount_account_id: "REC: wf1_discount_account.id"
+
+      - step: "Create the scholarship program"
+        action: "create"
+        model: "school_scholarship_program"
+        save_as: "wf1_program"
+        values:
+          name: "WF1 Program"
+          code: "WF1PRG"
+          type_id: "REC: wf1_type.id"
+          school_id: "REC: wf1_school.id"
+          academic_year_id: "REC: wf1_academic_year.id"
+          funding_source_ids: [[6, 0, ["REC: wf1_funding_source.id"]]]
+          deduction_journal_id: "REC: wf1_journal.id"
+          discount_account_id: "REC: wf1_discount_account.id"
+          scope_ids:
+            - - 0
+              - 0
+              - scope_basis: "product"
+                product_id: "REC: wf1_product.id"
+                benefit_type: "cash"
+                computation: "fixed"
+                percentage: 0.0
+                amount_fixed: 100000.0
+
+      # ── The Award's own Start Date (2026-09-01) falls AFTER the
+      # deduction's own Date (2026-08-01) below, so the deduction's
+      # Recognition Method computes to `deferred` and Recognition
+      # Date to 2026-09-01 -- exactly the boundary the wizard's own
+      # `date` field is set to further down ─────────────────────────
+      - step: "Create the award backing the due deduction"
+        action: "create"
+        model: "school_scholarship_award"
+        save_as: "wf1_award"
+        values:
+          program_id: "REC: wf1_program.id"
+          student_id: "REC: wf1_student.id"
+          enrollment_id: "REC: wf1_enrollment.id"
+          date_start: 2026-09-01
+          date_end: 2027-02-28
+          deferred_discount_account_id: "REC: wf1_deferred_account.id"
+          recognition_journal_id: "REC: wf1_journal.id"
+          benefit_ids:
+            - - 0
+              - 0
+              - name: "WF1 Benefit"
+                product_id: "REC: wf1_product.id"
+                benefit_type: "cash"
+                computation: "fixed"
+                amount_fixed: 400000.0
+                periodicity: "one_time"
+          funding_ids:
+            - - 0
+              - 0
+              - funding_source_id: "REC: wf1_funding_source.id"
+                percentage: 100.0
+
+      - step: "Find the award's Benefit line"
+        action: "search"
+        model: "school_scholarship_award_benefit"
+        domain: [["award_id", "=", "REC: wf1_award.id"]]
+        limit: 1
+        save_as: "wf1_benefit"
+
+      - step: "Find the award's Funding line"
+        action: "search"
+        model: "school_scholarship_award_funding"
+        domain: [["award_id", "=", "REC: wf1_award.id"]]
+        limit: 1
+        save_as: "wf1_funding"
+
+      - step: "Create the Schedule line realizing the Benefit"
+        action: "create"
+        model: "school_scholarship_award_schedule"
+        save_as: "wf1_schedule"
+        values:
+          benefit_id: "REC: wf1_benefit.id"
+          date: 2026-08-01
+          state: "scheduled"
+
+      - step: "Create the deferred, still-pending deduction due for recognition"
+        action: "create"
+        model: "school_scholarship_deduction"
+        save_as: "wf1_deduction"
+        values:
+          award_id: "REC: wf1_award.id"
+          date: 2026-08-01
+          journal_id: "REC: wf1_journal.id"
+          receivable_account_id: "REC: wf1_receivable_account.id"
+          deferred_account_id: "REC: wf1_deferred_account.id"
+          recognition_journal_id: "REC: wf1_journal.id"
+          user_id: "REF: base.user_admin"
+          line_ids:
+            - - 0
+              - 0
+              - schedule_id: "REC: wf1_schedule.id"
+                funding_id: "REC: wf1_funding.id"
+                final_account_id: "REC: wf1_discount_account.id"
+                name: "WF1 Deduction Line"
+                uom_quantity: 1
+                price_unit: 400000.0
+
+      - step: "Assert the deduction is deferred and pending, due 2026-09-01"
+        action: "assert"
+        target: "wf1_deduction"
+        asserts:
+          id:
+            type: "value"
+            operator: "is_truthy"
+          recognition_method:
+            type: "value"
+            expected: "deferred"
+          recognition_date:
+            type: "value"
+            expected: 2026-09-01
+          recognition_state:
+            type: "value"
+            expected: "pending"
+
+      # ── Onchange (form): changing Date on the wizard refreshes
+      # Deductions to every Pending, deferred deduction whose own
+      # Recognition Date falls on or before it -- exercised twice, so
+      # the SAME onchange is shown both excluding and including the
+      # fixture above, driven purely by the `date` value ─────────────
+      - step: "Open the wizard and set Date before the deduction is due"
+        action: "form"
+        model: "create_due_scholarship_recognition"
+        save: false
+        ops:
+          - set:
+              date: 2026-08-15
+          - assert:
+              deduction_ids:
+                type: "m2m"
+                check: "count"
+                expected_count: 0
+
+      - step: "Move Date on to the deduction's own Recognition Date"
+        action: "form"
+        model: "create_due_scholarship_recognition"
+        save: false
+        ops:
+          - set:
+              date: 2026-08-15
+          - set:
+              date: 2026-09-01
+          - assert:
+              deduction_ids:
+                type: "m2m"
+                check: "contains"
+                expected_records:
+                  - "REC: wf1_deduction"

--- a/ssi_school_scholarship_deduction/tests/test_data_create_due_scholarship_recognition.yaml
+++ b/ssi_school_scholarship_deduction/tests/test_data_create_due_scholarship_recognition.yaml
@@ -297,32 +297,47 @@ scenarios:
       # Deductions to every Pending, deferred deduction whose own
       # Recognition Date falls on or before it -- exercised twice, so
       # the SAME onchange is shown both excluding and including the
-      # fixture above, driven purely by the `date` value ─────────────
+      # fixture above, driven purely by the `date` value. Saved (not
+      # `save: false`) and asserted as a separate step on the
+      # persisted record: asserting `type: "m2m"` directly against
+      # the pending Form's own field returns Odoo's own `M2MProxy`
+      # helper, which `_coerce_to_ids` cannot interpret as a record
+      # reference -- only a real recordset exposes `.ids`. ───────────
       - step: "Open the wizard and set Date before the deduction is due"
         action: "form"
         model: "create_due_scholarship_recognition"
-        save: false
+        save: true
+        save_as: "wf1_wizard_before"
         ops:
           - set:
               date: 2026-08-15
-          - assert:
-              deduction_ids:
-                type: "m2m"
-                check: "count"
-                expected_count: 0
+
+      - step: "Deductions stay empty -- the fixture is not due yet"
+        action: "assert"
+        target: "wf1_wizard_before"
+        asserts:
+          deduction_ids:
+            type: "m2m"
+            check: "count"
+            expected_count: 0
 
       - step: "Move Date on to the deduction's own Recognition Date"
         action: "form"
         model: "create_due_scholarship_recognition"
-        save: false
+        save: true
+        save_as: "wf1_wizard_after"
         ops:
           - set:
               date: 2026-08-15
           - set:
               date: 2026-09-01
-          - assert:
-              deduction_ids:
-                type: "m2m"
-                check: "contains"
-                expected_records:
-                  - "REC: wf1_deduction"
+
+      - step: "Deductions now include the fixture, due as of 2026-09-01"
+        action: "assert"
+        target: "wf1_wizard_after"
+        asserts:
+          deduction_ids:
+            type: "m2m"
+            check: "contains"
+            expected_records:
+              - "REC: wf1_deduction"

--- a/ssi_school_scholarship_deduction/tests/test_data_create_due_scholarship_recognition.yaml
+++ b/ssi_school_scholarship_deduction/tests/test_data_create_due_scholarship_recognition.yaml
@@ -297,47 +297,48 @@ scenarios:
       # Deductions to every Pending, deferred deduction whose own
       # Recognition Date falls on or before it -- exercised twice, so
       # the SAME onchange is shown both excluding and including the
-      # fixture above, driven purely by the `date` value. Saved (not
-      # `save: false`) and asserted as a separate step on the
-      # persisted record: asserting `type: "m2m"` directly against
-      # the pending Form's own field returns Odoo's own `M2MProxy`
-      # helper, which `_coerce_to_ids` cannot interpret as a record
-      # reference -- only a real recordset exposes `.ids`. ───────────
+      # fixture above, driven purely by the `date` value. Asserted
+      # in-form (`save: false`), with `check: "count"` rather than
+      # `check: "contains"`: reading a m2m field off a *pending* Form
+      # returns Odoo's own `M2MProxy` helper, whose `__len__` the
+      # library's `count` check uses directly, but which lacks the
+      # `.ids` attribute `_coerce_to_ids` needs for `contains` --
+      # confirmed against ``odoo/tests/common.py``'s ``M2MProxy``
+      # (no ``.ids``, only ``Sequence``'s ``__len__``/``__iter__``/
+      # ``__contains__``). Only one deferred, Pending deduction
+      # exists in this scenario's own transaction, so `count`
+      # unambiguously proves the fixture was (or was not) picked up.
+      # Saving the wizard is deliberately avoided too: `deduction_ids`
+      # is unconditionally `readonly=True` with no view override, and
+      # ``action_create_due_recognition`` always reads it off the
+      # in-memory wizard state passed by the caller, never off a
+      # saved record -- there is nothing to gain from persisting it,
+      # and the pending-Form read is the one the DSL actually
+      # supports. ──────────────────────────────────────────────────
       - step: "Open the wizard and set Date before the deduction is due"
         action: "form"
         model: "create_due_scholarship_recognition"
-        save: true
-        save_as: "wf1_wizard_before"
+        save: false
         ops:
           - set:
               date: 2026-08-15
-
-      - step: "Deductions stay empty -- the fixture is not due yet"
-        action: "assert"
-        target: "wf1_wizard_before"
-        asserts:
-          deduction_ids:
-            type: "m2m"
-            check: "count"
-            expected_count: 0
+          - assert:
+              deduction_ids:
+                type: "m2m"
+                check: "count"
+                expected_count: 0
 
       - step: "Move Date on to the deduction's own Recognition Date"
         action: "form"
         model: "create_due_scholarship_recognition"
-        save: true
-        save_as: "wf1_wizard_after"
+        save: false
         ops:
           - set:
               date: 2026-08-15
           - set:
               date: 2026-09-01
-
-      - step: "Deductions now include the fixture, due as of 2026-09-01"
-        action: "assert"
-        target: "wf1_wizard_after"
-        asserts:
-          deduction_ids:
-            type: "m2m"
-            check: "contains"
-            expected_records:
-              - "REC: wf1_deduction"
+          - assert:
+              deduction_ids:
+                type: "m2m"
+                check: "count"
+                expected_count: 1

--- a/ssi_school_scholarship_deduction/tests/test_data_customer_invoice_scholarship_deduction.yaml
+++ b/ssi_school_scholarship_deduction/tests/test_data_customer_invoice_scholarship_deduction.yaml
@@ -524,6 +524,7 @@ scenarios:
       - step: "Assert e2_deduction still confirmed before approving (forces refresh)"
         action: "assert"
         target: "e2_deduction"
+        refresh: true
         asserts:
           state:
             type: "value"
@@ -1022,6 +1023,7 @@ scenarios:
       - step: "Assert e3_deduction still confirmed before approving (forces refresh)"
         action: "assert"
         target: "e3_deduction"
+        refresh: true
         asserts:
           state:
             type: "value"

--- a/ssi_school_scholarship_deduction/tests/test_data_customer_invoice_scholarship_deduction.yaml
+++ b/ssi_school_scholarship_deduction/tests/test_data_customer_invoice_scholarship_deduction.yaml
@@ -521,10 +521,13 @@ scenarios:
             type: "value"
             expected: "confirm"
 
-      - step: "Invalidate cache before approving (avoids stale policy cache)"
-        action: "call"
+      - step: "Assert e2_deduction still confirmed before approving (forces refresh)"
+        action: "assert"
         target: "e2_deduction"
-        method: "invalidate_cache"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
 
       - step: "Approve the deduction, reconciling 400000 off the invoice"
         action: "call"
@@ -1016,10 +1019,13 @@ scenarios:
         as_user: "base.user_admin"
         refresh: true
 
-      - step: "Invalidate cache before approving the full deduction"
-        action: "call"
+      - step: "Assert e3_deduction still confirmed before approving (forces refresh)"
+        action: "assert"
         target: "e3_deduction"
-        method: "invalidate_cache"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
 
       - step: "Approve the full deduction, fully reconciling the invoice"
         action: "call"

--- a/ssi_school_scholarship_deduction/tests/test_data_school_scholarship_deduction.yaml
+++ b/ssi_school_scholarship_deduction/tests/test_data_school_scholarship_deduction.yaml
@@ -385,10 +385,13 @@ scenarios:
             type: "value"
             expected: "confirm"
 
-      - step: "Invalidate cache before approving (avoids stale policy cache)"
-        action: "call"
+      - step: "Assert d1_deduction_partial still confirmed before approving (forces refresh)"
+        action: "assert"
         target: "d1_deduction_partial"
-        method: "invalidate_cache"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
 
       - step: "Approve the partial deduction, opening it"
         action: "call"
@@ -604,10 +607,13 @@ scenarios:
         as_user: "base.user_admin"
         refresh: true
 
-      - step: "Invalidate cache before approving the full deduction"
-        action: "call"
+      - step: "Assert d1_deduction_full still confirmed before approving (forces refresh)"
+        action: "assert"
         target: "d1_deduction_full"
-        method: "invalidate_cache"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
 
       - step: "Approve the full deduction, fully reconciling the invoice"
         action: "call"
@@ -1535,10 +1541,13 @@ scenarios:
         as_user: "base.user_admin"
         refresh: true
 
-      - step: "Invalidate cache before approving the mismatched deduction"
-        action: "call"
+      - step: "Assert d2_deduction_mismatch still confirmed before approving (forces refresh)"
+        action: "assert"
         target: "d2_deduction_mismatch"
-        method: "invalidate_cache"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
 
       - step: "Approving is rejected by the Receivable Account mismatch"
         action: "call"
@@ -1581,10 +1590,13 @@ scenarios:
         as_user: "base.user_admin"
         refresh: true
 
-      - step: "Invalidate cache before approving the under-allocated deduction"
-        action: "call"
+      - step: "Assert d2_deduction_unallocated still confirmed before approving (forces refresh)"
+        action: "assert"
         target: "d2_deduction_unallocated"
-        method: "invalidate_cache"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
 
       - step: "Approving is rejected by the nonzero Amount Unallocated"
         action: "call"
@@ -1704,10 +1716,13 @@ scenarios:
         as_user: "base.user_admin"
         refresh: true
 
-      - step: "Invalidate cache before approving the non-reconcilable deduction"
-        action: "call"
+      - step: "Assert d2_deduction_no_reconcile still confirmed before approving (forces refresh)"
+        action: "assert"
         target: "d2_deduction_no_reconcile"
-        method: "invalidate_cache"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
 
       - step: "Approving is rejected because the Receivable Account cannot reconcile"
         action: "call"
@@ -1805,10 +1820,13 @@ scenarios:
         as_user: "base.user_admin"
         refresh: true
 
-      - step: "Invalidate cache before approving the partner-mismatch deduction"
-        action: "call"
+      - step: "Assert d2_deduction_partner_mismatch still confirmed before approving (forces refresh)"
+        action: "assert"
         target: "d2_deduction_partner_mismatch"
-        method: "invalidate_cache"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
 
       - step: "Approving is rejected by the Partner mismatch"
         action: "call"
@@ -1899,10 +1917,13 @@ scenarios:
         as_user: "base.user_admin"
         refresh: true
 
-      - step: "Invalidate cache before approving the currency-mismatch deduction"
-        action: "call"
+      - step: "Assert d2_deduction_currency_mismatch still confirmed before approving (forces refresh)"
+        action: "assert"
         target: "d2_deduction_currency_mismatch"
-        method: "invalidate_cache"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
 
       - step: "Approving is rejected by the Currency mismatch"
         action: "call"
@@ -2023,10 +2044,13 @@ scenarios:
         as_user: "base.user_admin"
         refresh: true
 
-      - step: "Invalidate cache before approving the first shared deduction"
-        action: "call"
+      - step: "Assert d2_deduction_shared_first still confirmed before approving (forces refresh)"
+        action: "assert"
         target: "d2_deduction_shared_first"
-        method: "invalidate_cache"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
 
       - step: "Approve the first shared deduction, shrinking the invoice's residual"
         action: "call"
@@ -2055,10 +2079,13 @@ scenarios:
         as_user: "base.user_admin"
         refresh: true
 
-      - step: "Invalidate cache before approving the second shared deduction"
-        action: "call"
+      - step: "Assert d2_deduction_shared_second still confirmed before approving (forces refresh)"
+        action: "assert"
         target: "d2_deduction_shared_second"
-        method: "invalidate_cache"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
 
       - step:
           "Approving is rejected because the first deduction already used up the

--- a/ssi_school_scholarship_deduction/tests/test_data_school_scholarship_deduction.yaml
+++ b/ssi_school_scholarship_deduction/tests/test_data_school_scholarship_deduction.yaml
@@ -385,9 +385,11 @@ scenarios:
             type: "value"
             expected: "confirm"
 
-      - step: "Assert d1_deduction_partial still confirmed before approving (forces refresh)"
+      - step:
+          "Assert d1_deduction_partial still confirmed before approving (forces refresh)"
         action: "assert"
         target: "d1_deduction_partial"
+        refresh: true
         asserts:
           state:
             type: "value"
@@ -607,9 +609,11 @@ scenarios:
         as_user: "base.user_admin"
         refresh: true
 
-      - step: "Assert d1_deduction_full still confirmed before approving (forces refresh)"
+      - step:
+          "Assert d1_deduction_full still confirmed before approving (forces refresh)"
         action: "assert"
         target: "d1_deduction_full"
+        refresh: true
         asserts:
           state:
             type: "value"
@@ -1541,9 +1545,12 @@ scenarios:
         as_user: "base.user_admin"
         refresh: true
 
-      - step: "Assert d2_deduction_mismatch still confirmed before approving (forces refresh)"
+      - step:
+          "Assert d2_deduction_mismatch still confirmed before approving (forces
+          refresh)"
         action: "assert"
         target: "d2_deduction_mismatch"
+        refresh: true
         asserts:
           state:
             type: "value"
@@ -1590,9 +1597,12 @@ scenarios:
         as_user: "base.user_admin"
         refresh: true
 
-      - step: "Assert d2_deduction_unallocated still confirmed before approving (forces refresh)"
+      - step:
+          "Assert d2_deduction_unallocated still confirmed before approving (forces
+          refresh)"
         action: "assert"
         target: "d2_deduction_unallocated"
+        refresh: true
         asserts:
           state:
             type: "value"
@@ -1716,9 +1726,12 @@ scenarios:
         as_user: "base.user_admin"
         refresh: true
 
-      - step: "Assert d2_deduction_no_reconcile still confirmed before approving (forces refresh)"
+      - step:
+          "Assert d2_deduction_no_reconcile still confirmed before approving (forces
+          refresh)"
         action: "assert"
         target: "d2_deduction_no_reconcile"
+        refresh: true
         asserts:
           state:
             type: "value"
@@ -1820,9 +1833,12 @@ scenarios:
         as_user: "base.user_admin"
         refresh: true
 
-      - step: "Assert d2_deduction_partner_mismatch still confirmed before approving (forces refresh)"
+      - step:
+          "Assert d2_deduction_partner_mismatch still confirmed before approving (forces
+          refresh)"
         action: "assert"
         target: "d2_deduction_partner_mismatch"
+        refresh: true
         asserts:
           state:
             type: "value"
@@ -1917,9 +1933,12 @@ scenarios:
         as_user: "base.user_admin"
         refresh: true
 
-      - step: "Assert d2_deduction_currency_mismatch still confirmed before approving (forces refresh)"
+      - step:
+          "Assert d2_deduction_currency_mismatch still confirmed before approving
+          (forces refresh)"
         action: "assert"
         target: "d2_deduction_currency_mismatch"
+        refresh: true
         asserts:
           state:
             type: "value"
@@ -2044,9 +2063,12 @@ scenarios:
         as_user: "base.user_admin"
         refresh: true
 
-      - step: "Assert d2_deduction_shared_first still confirmed before approving (forces refresh)"
+      - step:
+          "Assert d2_deduction_shared_first still confirmed before approving (forces
+          refresh)"
         action: "assert"
         target: "d2_deduction_shared_first"
+        refresh: true
         asserts:
           state:
             type: "value"
@@ -2079,9 +2101,12 @@ scenarios:
         as_user: "base.user_admin"
         refresh: true
 
-      - step: "Assert d2_deduction_shared_second still confirmed before approving (forces refresh)"
+      - step:
+          "Assert d2_deduction_shared_second still confirmed before approving (forces
+          refresh)"
         action: "assert"
         target: "d2_deduction_shared_second"
+        refresh: true
         asserts:
           state:
             type: "value"


### PR DESCRIPTION
## Ringkasan

Menyelesaikan open-synergy/ssi-school-scholarship#52.

- Mencabut 11 step manual `action: call` + `method: "invalidate_cache"` di
  `tests/test_data_customer_invoice_scholarship_deduction.yaml` (2 titik) dan
  `tests/test_data_school_scholarship_deduction.yaml` (9 titik) — lebih banyak
  dari 6 titik yang disebut di badan issue, karena pola yang sama juga muncul
  di lima skenario negative-path yang belum tercakup saat audit 12 Agustus.
  `invalidate_cache` adalah API ORM yang dihapus di Odoo 17.0.
- Setiap step diganti step `assert` atas field `state` (`"confirm"`) tepat
  sebelum approve — pola `T-04` (`odoo-development-unit-test`
  `references/test-traps.md`): step assert memaksa `_refresh()` pustaka tanpa
  API yang version-coupled ke 14.0. Tidak memakai `options: {auto_refresh: true}`
  level-berkas (dilarang Keputusan Desain issue — berkas memakai `as_user`,
  refresh global memicu jebakan `T-05`).
- Menambah skenario `action: form` baru untuk `onchange_deduction_ids` pada
  wizard `create_due_scholarship_recognition` (`tests/test_data_create_due_scholarship_recognition.yaml`
  + `tests/test_create_due_scholarship_recognition.py`, terdaftar di
  `tests/__init__.py`), diuji pada model wizard-nya sendiri sesuai Keputusan
  Desain — bukan lewat `action: wizard`.
- Sembilan onchange lain modul ini (`onchange_receivable_account_id`,
  `onchange_deferred_account_id`, `onchange_recognition_journal_id` pada
  `school_scholarship_deduction`; `onchange_name`, `onchange_product_id`,
  `onchange_final_account_id`, `onchange_price_unit` pada
  `school_scholarship_deduction_line`; `onchange_amount`, `onchange_journal_id`
  pada `school_scholarship_deduction_recognition`) sudah tercakup skenario
  `action: form` yang ditambahkan PR #63 (issue #51) sebelum item ini
  dikerjakan — diverifikasi manual, tidak diduplikasi di sini.

## Catatan validator

`validate-unit-test.sh ssi_school_scholarship_deduction 14.0` melaporkan
`error=0` (LOLOS) tapi masih mencetak 1 peringatan "setiap @api.onchange diuji
dengan action: form — 10 onchange di model, nol 'action: form' di YAML".
Ini **false positive** dari bug regex validator sendiri
(`odoo-development-unit-test` skill, `assets/validate-unit-test.sh` baris ~583):
regex-nya `action\s*:\s*form\b` tidak menghitung style kutip yang dipakai
konsisten di seluruh DSL YAML proyek ini (`action: "form"`, bukan
`action: form` tanpa kutip) — dikonfirmasi lewat pengujian regex langsung
terhadap isi berkas. Perbaikan regex itu di luar lingkup PR ini (`tests/`
modul ini saja) karena validator hidup di repo skill terpisah
(`odoo-development-unit-test-skill`).

```
#VALIDATOR name=unit-test target=ssi_school_scholarship_deduction series=14.0 error=0 warn=1 defer=0 excepted=0 status=OK
```

## Test plan

- [ ] CI hijau (`pre-commit` + `test.yml`)

Closes open-synergy/ssi-school-scholarship#52