### PR TITLE
[UPD] ssi_school_scholarship_disbursement - isi Payment Method disbursement due otomatis

### DIFF
--- a/ssi_school_scholarship_disbursement/models/school_scholarship_award.py
+++ b/ssi_school_scholarship_disbursement/models/school_scholarship_award.py
@@ -122,6 +122,14 @@ class SchoolScholarshipAward(models.Model):
         Extension point: override to carry extra header fields into
         a newly created document.
 
+        Always sets ``payment_method`` to ``cash`` and leaves
+        ``bank_account_id`` empty, so the created document satisfies
+        ``_check_bank_account_required`` unconditionally -- neither
+        the wizard button nor a plain call site has a safe source for
+        a Bank Account. The document is still created in ``draft``,
+        so ``payment_method``/``bank_account_id`` remain editable by
+        the user afterwards.
+
         :param schedules: the due ``school_scholarship_award_schedule``
             recordset this document realizes
         :return: dict of ``school_scholarship_disbursement`` values,
@@ -145,6 +153,7 @@ class SchoolScholarshipAward(models.Model):
             "date_due": today,
             "journal_id": self.disbursement_journal_id.id,
             "payable_account_id": self.payable_account_id.id,
+            "payment_method": "cash",
             "line_ids": line_values,
         }
 

--- a/ssi_school_scholarship_disbursement/tests/test_data_school_scholarship_disbursement.yaml
+++ b/ssi_school_scholarship_disbursement/tests/test_data_school_scholarship_disbursement.yaml
@@ -1396,18 +1396,14 @@ scenarios:
           date_end: 2026-12-31
 
       - step:
-          "Run the wizard, realizing the due Cash Schedule line. Neither
-          _prepare_due_disbursement_data nor the wizard itself sets
-          payment_method/bank_account_id on the new document, so the field's own default
-          (bank_transfer) would otherwise trip _check_bank_account_required for want of
-          a Bank Account -- default_payment_method steers the created document to cash
-          instead, matching the Cash Benefit/Cash Schedule line it realizes, without
-          touching production code."
+          "Run the wizard, realizing the due Cash Schedule line. No payment/bank field
+          is set anywhere on this call -- neither on the wizard nor via context -- so
+          this exercises _prepare_due_disbursement_data's own fix: it now sets
+          payment_method to cash on the dict it returns, which is what lets the created
+          document satisfy _check_bank_account_required without a Bank Account."
         action: "call"
         target: "b3_wizard_due"
         method: "action_create_due_disbursement"
-        context:
-          default_payment_method: "cash"
 
       - step: "Assert exactly one Disbursement document was created"
         action: "search"
@@ -1424,6 +1420,19 @@ scenarios:
             type: "value"
             expected: "draft"
 
+      - step:
+          "Assert the created Disbursement defaults to Payment Method cash, with no Bank
+          Account -- confirming the fix without relying on any caller-supplied context"
+        action: "assert"
+        target: "b3_disbursement_due"
+        asserts:
+          payment_method:
+            type: "value"
+            expected: "cash"
+          bank_account_id:
+            type: "value"
+            operator: "is_falsy"
+
       - step: "Find the created Disbursement's own line"
         action: "search"
         model: "school_scholarship_disbursement_line"
@@ -1438,6 +1447,37 @@ scenarios:
           schedule_id:
             type: "m2o"
             expected: "REC: b3_schedule_due"
+
+      # ── Regression: payment_method/bank_account_id must remain
+      # manually editable while the document is still draft -- the
+      # fix must not turn either field permanently readonly ─────────
+      - step: "Create the Bank Account used by the manual switch below"
+        action: "create"
+        model: "res.partner.bank"
+        save_as: "b3_bank_account"
+        values:
+          acc_number: "B3-ACC-0001"
+          partner_id: "REC: b3_contact.id"
+
+      - step:
+          "Switch the still-draft Disbursement to Bank Transfer with a Bank Account,
+          proving the field the fix defaults to cash is not locked read-only afterwards"
+        action: "write"
+        target: "b3_disbursement_due"
+        values:
+          payment_method: "bank_transfer"
+          bank_account_id: "REC: b3_bank_account.id"
+
+      - step: "Assert the manual switch to Bank Transfer took effect"
+        action: "assert"
+        target: "b3_disbursement_due"
+        asserts:
+          payment_method:
+            type: "value"
+            expected: "bank_transfer"
+          bank_account_id:
+            type: "m2o"
+            expected: "REC: b3_bank_account"
 
       # ── Negative: an Award with no Schedule line at all raises
       # UserError and creates no Disbursement document ───────────────


### PR DESCRIPTION
## Ringkasan

`_prepare_due_disbursement_data()` kini mengisi `payment_method = "cash"` pada dokumen
`school_scholarship_disbursement` yang dibuat otomatis dari Award berdasarkan Cash
Schedule due. Sebelumnya dict yang dikembalikan tidak menyertakan `payment_method` sama
sekali, sehingga default ORM-nya (`bank_transfer`) langsung melanggar constraint
`_check_bank_account_required` karena `bank_account_id` belum terisi -- dokumen baru
gagal dibuat sebelum sempat mencapai state `draft` yang bisa diedit user.

`bank_account_id` sengaja dibiarkan kosong -- tidak ada sumber data yang aman untuk
mengisinya otomatis dari Award/Benefit/Funding/Program. Dokumen tetap lahir di state
`draft` sehingga `payment_method` dan `bank_account_id` tetap bisa diubah manual oleh
user.

Prasyarat untuk tour "Create Due Disbursement" (issue #62/PR #67), yang sebelumnya
tertahan karena wizard-nya tidak punya field payment/bank apa pun untuk diisi user
sebelum submit.

## Kriteria Penerimaan

- [x] `action_create_due_disbursement()` dipanggil pada Award dengan Cash Schedule due,
      tanpa mengisi apa pun soal payment/bank sebelumnya, berhasil membuat dokumen
      `school_scholarship_disbursement` tanpa `ValidationError`.
- [x] Dokumen yang dihasilkan punya `payment_method == "cash"` dan `bank_account_id`
      kosong.
- [x] `bank_account_id`/`payment_method` tetap bisa diubah manual selama dokumen
      `draft` (regresi negatif ditambahkan).
- [x] Workaround `context: {default_payment_method: "cash"}` (issue #53/PR #65) sudah
      dihapus karena redundan.

## Validasi lokal

```
#VALIDATOR name=module target=ssi_school_scholarship_disbursement series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=unit-test target=ssi_school_scholarship_disbursement series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#GATE repo=ssi-school-scholarship-68 modules=1 failed=0 skipped=0 status=OK
```

Closes #68