### PR TITLE
[UPD] ssi_school_scholarship - catat vonis N tombol Open Scholarship Award di IK Award

### DIFF
--- a/ssi_school_scholarship/docs/school_scholarship_award/01-create.md
+++ b/ssi_school_scholarship/docs/school_scholarship_award/01-create.md
@@ -75,3 +75,11 @@
 - A new Scholarship Award record is created in **Draft** status.
 - **Amount Awarded** is recomputed as the sum of the Benefit lines' amounts.
 - **Compliance State** defaults to **Active**.
+
+## Related Views
+
+- The **Awards** stat button in the button box of the Student form and the Enrollment
+  form (`action_open_scholarship_award`) opens the list of Scholarship Award records of
+  that Student or Enrollment. It only returns an `act_window` and writes no field, so it
+  is pure navigation: informational only, not documented as an IK step or tour of its
+  own.


### PR DESCRIPTION
## Ringkasan

Menambahkan bagian `## Related Views` pada `docs/school_scholarship_award/01-create.md`
untuk mencatat tombol **Awards** (`action_open_scholarship_award`) yang terpasang di
button box form `school_student` dan `school_enrollment`.

Sesuai temuan sapuan kepatuhan (`audit-sweep.sh 14.0`, 12 Agustus 2026): tombol ini
bervonis **N (nol IK)** — hanya mengembalikan `ir.actions.act_window` untuk membuka
daftar Scholarship Award milik record tersebut, tanpa menulis field apa pun. Karena itu
tidak dibuat file IK baru, langkah inline, maupun tour — hanya catatan informasional pada
IK model yang dituju tombolnya (`school_scholarship_award`).

## Test plan

- [x] `validate-ik.sh ssi_school_scholarship 14.0` → `error=0 warn=0 defer=0`
- [x] `pre-commit-gate.sh` → GATE OK, 0 pelanggaran baru
- [ ] CI GitHub hijau

Closes #55