### PR TITLE
[UPD] ssi_school_scholarship - rapikan tata letak form/tree/search school_scholarship_award

### DIFF
--- a/ssi_school_scholarship/__manifest__.py
+++ b/ssi_school_scholarship/__manifest__.py
@@ -56,6 +56,7 @@
         "views/school_scholarship_program.xml",
         "views/school_scholarship_letter.xml",
         "views/school_scholarship_award.xml",
+        "views/school_scholarship_award_schedule.xml",
         "views/school_student.xml",
         "views/school_enrollment.xml",
         "views/assets.xml",

--- a/ssi_school_scholarship/docs/school_scholarship_award/01-create.md
+++ b/ssi_school_scholarship/docs/school_scholarship_award/01-create.md
@@ -83,3 +83,9 @@
   that Student or Enrollment. It only returns an `act_window` and writes no field, so it
   is pure navigation: informational only, not documented as an IK step or tour of its
   own.
+- The **Schedule Lines** stat button in this form's own button box
+  (`action_view_schedule`) opens the list of this award's Schedule lines, of any state.
+  Pure navigation: no field is written and no state changes.
+- The **Realized Schedules** stat button in this form's own button box
+  (`action_view_realized_schedule`) opens the list of this award's Schedule lines
+  already in state Realized. Pure navigation, same as above.

--- a/ssi_school_scholarship/models/school_scholarship_award.py
+++ b/ssi_school_scholarship/models/school_scholarship_award.py
@@ -896,6 +896,49 @@ Solution: Use revocation instead of cancellation for an award already realized
         for record in self.sudo():
             record._generate_schedule()
 
+    def action_view_schedule(self):
+        """Open this award's Schedule lines, of any state.
+
+        Pure navigation: no field is written and no state changes --
+        the smart button this backs shows the count of
+        ``schedule_ids``, and this is its door.
+
+        :return: an ``ir.actions.act_window`` dict listing this
+            award's ``school_scholarship_award_schedule`` records
+        """
+        self.ensure_one()
+        return {
+            "name": _("Schedule Lines"),
+            "type": "ir.actions.act_window",
+            "res_model": "school_scholarship_award_schedule",
+            "view_mode": "tree,form",
+            "domain": [("award_id", "=", self.id)],
+            "context": {"default_award_id": self.id},
+        }
+
+    def action_view_realized_schedule(self):
+        """Open this award's Schedule lines already realized.
+
+        Pure navigation, same as ``action_view_schedule`` -- the
+        smart button this backs shows the count of ``realized_count``.
+
+        :return: an ``ir.actions.act_window`` dict listing this
+            award's ``school_scholarship_award_schedule`` records
+            in state ``realized``
+        """
+        self.ensure_one()
+        return {
+            "name": _("Realized Schedules"),
+            "type": "ir.actions.act_window",
+            "res_model": "school_scholarship_award_schedule",
+            "view_mode": "tree,form",
+            "domain": [
+                ("award_id", "=", self.id),
+                ("state", "=", "realized"),
+            ],
+            "context": {"default_award_id": self.id},
+        }
+
     def _generate_schedule(self):
         """Idempotently create Schedule lines for every Benefit line.
 

--- a/ssi_school_scholarship/tests/test_school_scholarship_award.py
+++ b/ssi_school_scholarship/tests/test_school_scholarship_award.py
@@ -37,3 +37,213 @@ class TestSchoolScholarshipAward(YamlTransactionCase):
         ):
             result = award._insert_form_element(view_arch)
         self.assertEqual(result, view_arch)
+
+
+@tagged("post_install", "-at_install")
+class TestSchoolScholarshipAwardViewActions(YamlTransactionCase):
+    """Tests for the ``action_view_schedule`` smart button actions.
+
+    Fixture built here in Python, not via YAML -- these two actions
+    only return an ``ir.actions.act_window`` dict, so asserting their
+    ``domain``/``res_model`` is trigger P1 (L-01, L-02: a ``call``
+    step in ``odoo-yaml-test`` discards a method's return value), and
+    the pustaka's registry does not survive past ``run_yaml_scenario``
+    for a later method to reuse (odoo-development-unit-test
+    references/python-escape-hatch.md §4).
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Build one award with 5 Schedule lines (2 realized), plus a
+        second bare award used only for the ``ensure_one`` negative
+        path.
+        """
+        super().setUpClass()
+        grade_type = cls.env["school_grade_type"].create(
+            {"name": "AV Grade Type", "code": "AVGT"}
+        )
+        school = cls.env["school"].create(
+            {
+                "name": "AV School",
+                "code": "AVSC",
+                "grade_type_id": grade_type.id,
+            }
+        )
+        academic_year = cls.env["school_academic_year"].create(
+            {
+                "name": "AV Academic Year",
+                "code": "AVAY",
+                "date_start": "2026-07-01",
+                "date_end": "2027-06-30",
+            }
+        )
+        academic_term = cls.env["school_academic_term"].create(
+            {
+                "name": "AV Term",
+                "code": "AVTM",
+                "date_start": "2026-07-01",
+                "date_end": "2026-12-31",
+                "year_id": academic_year.id,
+            }
+        )
+        grade = cls.env["school_grade"].create(
+            {"name": "AV Grade", "code": "AVGR", "type_id": grade_type.id}
+        )
+        grade_class = cls.env["school_grade_class"].create(
+            {
+                "name": "AV Class",
+                "code": "AVCL",
+                "school_id": school.id,
+                "grade_id": grade.id,
+            }
+        )
+        contact = cls.env["res.partner"].create({"name": "AV Contact"})
+        student = cls.env["school_student"].create(
+            {
+                "name": "AV Student",
+                "code": "AVST",
+                "contact_id": contact.id,
+                "school_id": school.id,
+            }
+        )
+        enrollment = cls.env["school_enrollment"].create(
+            {
+                "academic_year_id": academic_year.id,
+                "academic_term_id": academic_term.id,
+                "school_id": school.id,
+                "grade_id": grade.id,
+                "grade_class_id": grade_class.id,
+                "student_id": student.id,
+            }
+        )
+        product = cls.env["product.product"].create(
+            {"name": "AV Product", "type": "service"}
+        )
+        journal = cls.env["account.journal"].create(
+            {"name": "AV Journal", "code": "JAV", "type": "sale"}
+        )
+        account_type_income = cls.env.ref("account.data_account_type_revenue")
+        discount_account = cls.env["account.account"].create(
+            {
+                "name": "AV Discount Account",
+                "code": "AVDA",
+                "user_type_id": account_type_income.id,
+                "reconcile": False,
+            }
+        )
+        scholarship_type = cls.env["school_scholarship_type"].create(
+            {
+                "name": "AV Type",
+                "code": "AVTY",
+                "deduction_journal_id": journal.id,
+                "discount_account_id": discount_account.id,
+            }
+        )
+        program = cls.env["school_scholarship_program"].create(
+            {
+                "name": "AV Program",
+                "code": "AVPRG",
+                "type_id": scholarship_type.id,
+                "school_id": school.id,
+                "academic_year_id": academic_year.id,
+                "deduction_journal_id": journal.id,
+                "discount_account_id": discount_account.id,
+            }
+        )
+        # 1 One Time line + 4 Monthly lines (Jul..Oct, one per month)
+        # once generated -- see ``_get_cash_schedule_dates``.
+        cls.award = cls.env["school_scholarship_award"].create(
+            {
+                "program_id": program.id,
+                "student_id": student.id,
+                "enrollment_id": enrollment.id,
+                "date_start": "2026-07-01",
+                "date_end": "2026-10-31",
+                "benefit_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "AV Benefit One Time",
+                            "product_id": product.id,
+                            "benefit_type": "cash",
+                            "computation": "fixed",
+                            "amount_fixed": 100000.0,
+                            "periodicity": "one_time",
+                        },
+                    ),
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "AV Benefit Monthly",
+                            "product_id": product.id,
+                            "benefit_type": "cash",
+                            "computation": "fixed",
+                            "amount_fixed": 50000.0,
+                            "periodicity": "monthly",
+                        },
+                    ),
+                ],
+            }
+        )
+        cls.award.with_context(bypass_policy_check=True)._generate_schedule()
+        cls.realized_schedules = cls.award.schedule_ids[:2]
+        cls.realized_schedules.write({"state": "realized"})
+
+        # A second, bare award (no Benefit line needed) purely to
+        # form a 2-record recordset for the ``ensure_one`` check.
+        cls.other_award = cls.env["school_scholarship_award"].create(
+            {
+                "program_id": program.id,
+                "student_id": student.id,
+                "enrollment_id": enrollment.id,
+                "date_start": "2026-07-01",
+                "date_end": "2026-07-31",
+            }
+        )
+
+    def test_action_view_schedule_lists_all_lines(self):
+        """``action_view_schedule`` opens all of this award's lines.
+
+        Pure Python -- trigger P1 (L-01, L-02: the returned
+        ``ir.actions.act_window`` dict cannot be asserted through
+        ``odoo-yaml-test``'s ``call`` action).
+        """
+        action = self.award.action_view_schedule()
+        self.assertEqual(action["res_model"], "school_scholarship_award_schedule")
+        self.assertEqual(action["type"], "ir.actions.act_window")
+        self.assertEqual(action["domain"], [("award_id", "=", self.award.id)])
+        found = self.env[action["res_model"]].search(action["domain"])
+        self.assertEqual(found, self.award.schedule_ids)
+        self.assertEqual(len(found), 5)
+
+    def test_action_view_realized_schedule_lists_only_realized(self):
+        """``action_view_realized_schedule`` opens only the Realized
+        lines.
+
+        Pure Python -- trigger P1 (L-01, L-02: same as
+        ``test_action_view_schedule_lists_all_lines``).
+        """
+        action = self.award.action_view_realized_schedule()
+        self.assertEqual(action["res_model"], "school_scholarship_award_schedule")
+        self.assertEqual(
+            action["domain"],
+            [("award_id", "=", self.award.id), ("state", "=", "realized")],
+        )
+        found = self.env[action["res_model"]].search(action["domain"])
+        self.assertEqual(found, self.realized_schedules)
+        self.assertEqual(len(found), 2)
+
+    def test_action_view_schedule_ensure_one_on_multiple_awards(self):
+        """Calling either action on more than one award must fail.
+
+        Pure Python -- trigger P1 (L-01, L-02: the failure mode of a
+        method whose return value ``odoo-yaml-test`` cannot inspect
+        is exercised the same way its success path is).
+        """
+        both_awards = self.award | self.other_award
+        with self.assertRaises(ValueError):
+            both_awards.action_view_schedule()
+        with self.assertRaises(ValueError):
+            both_awards.action_view_realized_schedule()

--- a/ssi_school_scholarship/tests/test_school_scholarship_award.py
+++ b/ssi_school_scholarship/tests/test_school_scholarship_award.py
@@ -147,6 +147,19 @@ class TestSchoolScholarshipAwardViewActions(YamlTransactionCase):
                 "academic_year_id": academic_year.id,
                 "deduction_journal_id": journal.id,
                 "discount_account_id": discount_account.id,
+                "scope_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "scope_basis": "product",
+                            "product_id": product.id,
+                            "benefit_type": "fee_reduction",
+                            "computation": "percentage",
+                            "percentage": 40.0,
+                        },
+                    )
+                ],
             }
         )
         # 1 One Time line + 4 Monthly lines (Jul..Oct, one per month)

--- a/ssi_school_scholarship/tests/test_school_scholarship_award.py
+++ b/ssi_school_scholarship/tests/test_school_scholarship_award.py
@@ -52,24 +52,23 @@ class TestSchoolScholarshipAwardViewActions(YamlTransactionCase):
     references/python-escape-hatch.md §4).
     """
 
-    @classmethod
-    def setUpClass(cls):
+    def setUp(self):
         """Build one award with 5 Schedule lines (2 realized), plus a
         second bare award used only for the ``ensure_one`` negative
         path.
         """
-        super().setUpClass()
-        grade_type = cls.env["school_grade_type"].create(
+        super().setUp()
+        grade_type = self.env["school_grade_type"].create(
             {"name": "AV Grade Type", "code": "AVGT"}
         )
-        school = cls.env["school"].create(
+        school = self.env["school"].create(
             {
                 "name": "AV School",
                 "code": "AVSC",
                 "grade_type_id": grade_type.id,
             }
         )
-        academic_year = cls.env["school_academic_year"].create(
+        academic_year = self.env["school_academic_year"].create(
             {
                 "name": "AV Academic Year",
                 "code": "AVAY",
@@ -77,7 +76,7 @@ class TestSchoolScholarshipAwardViewActions(YamlTransactionCase):
                 "date_end": "2027-06-30",
             }
         )
-        academic_term = cls.env["school_academic_term"].create(
+        academic_term = self.env["school_academic_term"].create(
             {
                 "name": "AV Term",
                 "code": "AVTM",
@@ -86,10 +85,10 @@ class TestSchoolScholarshipAwardViewActions(YamlTransactionCase):
                 "year_id": academic_year.id,
             }
         )
-        grade = cls.env["school_grade"].create(
+        grade = self.env["school_grade"].create(
             {"name": "AV Grade", "code": "AVGR", "type_id": grade_type.id}
         )
-        grade_class = cls.env["school_grade_class"].create(
+        grade_class = self.env["school_grade_class"].create(
             {
                 "name": "AV Class",
                 "code": "AVCL",
@@ -97,8 +96,8 @@ class TestSchoolScholarshipAwardViewActions(YamlTransactionCase):
                 "grade_id": grade.id,
             }
         )
-        contact = cls.env["res.partner"].create({"name": "AV Contact"})
-        student = cls.env["school_student"].create(
+        contact = self.env["res.partner"].create({"name": "AV Contact"})
+        student = self.env["school_student"].create(
             {
                 "name": "AV Student",
                 "code": "AVST",
@@ -106,7 +105,7 @@ class TestSchoolScholarshipAwardViewActions(YamlTransactionCase):
                 "school_id": school.id,
             }
         )
-        enrollment = cls.env["school_enrollment"].create(
+        enrollment = self.env["school_enrollment"].create(
             {
                 "academic_year_id": academic_year.id,
                 "academic_term_id": academic_term.id,
@@ -116,14 +115,14 @@ class TestSchoolScholarshipAwardViewActions(YamlTransactionCase):
                 "student_id": student.id,
             }
         )
-        product = cls.env["product.product"].create(
+        product = self.env["product.product"].create(
             {"name": "AV Product", "type": "service"}
         )
-        journal = cls.env["account.journal"].create(
+        journal = self.env["account.journal"].create(
             {"name": "AV Journal", "code": "JAV", "type": "sale"}
         )
-        account_type_income = cls.env.ref("account.data_account_type_revenue")
-        discount_account = cls.env["account.account"].create(
+        account_type_income = self.env.ref("account.data_account_type_revenue")
+        discount_account = self.env["account.account"].create(
             {
                 "name": "AV Discount Account",
                 "code": "AVDA",
@@ -131,7 +130,7 @@ class TestSchoolScholarshipAwardViewActions(YamlTransactionCase):
                 "reconcile": False,
             }
         )
-        scholarship_type = cls.env["school_scholarship_type"].create(
+        scholarship_type = self.env["school_scholarship_type"].create(
             {
                 "name": "AV Type",
                 "code": "AVTY",
@@ -139,7 +138,7 @@ class TestSchoolScholarshipAwardViewActions(YamlTransactionCase):
                 "discount_account_id": discount_account.id,
             }
         )
-        program = cls.env["school_scholarship_program"].create(
+        program = self.env["school_scholarship_program"].create(
             {
                 "name": "AV Program",
                 "code": "AVPRG",
@@ -152,7 +151,7 @@ class TestSchoolScholarshipAwardViewActions(YamlTransactionCase):
         )
         # 1 One Time line + 4 Monthly lines (Jul..Oct, one per month)
         # once generated -- see ``_get_cash_schedule_dates``.
-        cls.award = cls.env["school_scholarship_award"].create(
+        self.award = self.env["school_scholarship_award"].create(
             {
                 "program_id": program.id,
                 "student_id": student.id,
@@ -187,13 +186,13 @@ class TestSchoolScholarshipAwardViewActions(YamlTransactionCase):
                 ],
             }
         )
-        cls.award.with_context(bypass_policy_check=True)._generate_schedule()
-        cls.realized_schedules = cls.award.schedule_ids[:2]
-        cls.realized_schedules.write({"state": "realized"})
+        self.award.with_context(bypass_policy_check=True)._generate_schedule()
+        self.realized_schedules = self.award.schedule_ids[:2]
+        self.realized_schedules.write({"state": "realized"})
 
         # A second, bare award (no Benefit line needed) purely to
         # form a 2-record recordset for the ``ensure_one`` check.
-        cls.other_award = cls.env["school_scholarship_award"].create(
+        self.other_award = self.env["school_scholarship_award"].create(
             {
                 "program_id": program.id,
                 "student_id": student.id,

--- a/ssi_school_scholarship/views/school_scholarship_award.xml
+++ b/ssi_school_scholarship/views/school_scholarship_award.xml
@@ -19,23 +19,23 @@
                 <field name="school_id" />
                 <field name="academic_year_id" />
                 <field name="compliance_state" />
-                <group expand="0" string="Group By">
-                    <filter
-                            name="group_by_program_id"
-                            string="Program"
-                            context="{'group_by': 'program_id'}"
-                        />
-                    <filter
-                            name="group_by_school_id"
-                            string="School"
-                            context="{'group_by': 'school_id'}"
-                        />
-                    <filter
-                            name="group_by_compliance_state"
-                            string="Compliance State"
-                            context="{'group_by': 'compliance_state'}"
-                        />
-                </group>
+            </xpath>
+            <xpath expr="//group[@name='group_by']" position="inside">
+                <filter
+                        name="group_by_program_id"
+                        string="Program"
+                        context="{'group_by': 'program_id'}"
+                    />
+                <filter
+                        name="group_by_school_id"
+                        string="School"
+                        context="{'group_by': 'school_id'}"
+                    />
+                <filter
+                        name="group_by_compliance_state"
+                        string="Compliance State"
+                        context="{'group_by': 'compliance_state'}"
+                    />
             </xpath>
         </data>
     </field>
@@ -51,12 +51,12 @@
             <xpath expr="//field[@name='company_id']" position="after">
                 <field name="date" />
                 <field name="student_id" />
-                <field name="program_id" />
-                <field name="school_id" />
-                <field name="date_start" />
-                <field name="date_end" />
                 <field name="amount_awarded" widget="monetary" />
-                <field name="compliance_state" />
+                <field name="program_id" optional="hide" />
+                <field name="school_id" optional="hide" />
+                <field name="date_start" optional="hide" />
+                <field name="date_end" optional="hide" />
+                <field name="compliance_state" optional="hide" />
                 <field name="company_currency_id" invisible="1" />
             </xpath>
         </data>
@@ -71,13 +71,39 @@
     <field name="arch" type="xml">
         <data>
             <xpath expr="//header" position="inside">
-                <field name="generate_schedule_ok" invisible="1" />
                 <button
                         name="action_generate_schedule"
                         type="object"
                         string="Generate Schedule"
+                        class="oe_highlight"
                         attrs="{'invisible': [('generate_schedule_ok', '=', False)]}"
                     />
+            </xpath>
+            <xpath expr="//div[@name='button_box']" position="inside">
+                <button
+                        name="action_view_schedule"
+                        type="object"
+                        class="oe_stat_button"
+                        icon="fa-calendar"
+                    >
+                    <field
+                            name="schedule_count"
+                            widget="statinfo"
+                            string="Schedule Lines"
+                        />
+                </button>
+                <button
+                        name="action_view_realized_schedule"
+                        type="object"
+                        class="oe_stat_button"
+                        icon="fa-check-square-o"
+                    >
+                    <field
+                            name="realized_count"
+                            widget="statinfo"
+                            string="Realized Schedules"
+                        />
+                </button>
             </xpath>
             <xpath expr="//field[@name='user_id']" position="after">
                 <field name="program_id" />
@@ -98,7 +124,8 @@
             </xpath>
             <xpath expr="//group[@name='header_right']" position="inside">
                 <field name="date" />
-                <field name="compliance_state" />
+            </xpath>
+            <xpath expr="//group[@name='footer_left']" position="inside">
                 <field name="company_currency_id" invisible="1" />
                 <field
                         name="amount_awarded"
@@ -115,8 +142,6 @@
                         widget="monetary"
                         options="{'currency_field': 'company_currency_id'}"
                     />
-                <field name="schedule_count" />
-                <field name="realized_count" />
             </xpath>
             <xpath expr="//page[1]" position="before">
                 <page name="benefit" string="Benefit">

--- a/ssi_school_scholarship/views/school_scholarship_award_schedule.xml
+++ b/ssi_school_scholarship/views/school_scholarship_award_schedule.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+<record id="school_scholarship_award_schedule_view_tree" model="ir.ui.view">
+    <field name="name">school_scholarship_award_schedule - tree</field>
+    <field name="model">school_scholarship_award_schedule</field>
+    <field name="arch" type="xml">
+        <tree>
+            <field name="award_id" />
+            <field name="benefit_id" />
+            <field name="date" />
+            <field name="amount_planned" widget="monetary" />
+            <field name="amount_realized" widget="monetary" />
+            <field name="state" widget="badge" />
+            <field name="payment_term_id" optional="hide" />
+            <field name="base_amount" widget="monetary" optional="hide" />
+            <field name="amount_planned_manual" optional="hide" />
+            <field name="payment_term_state" optional="hide" />
+            <field name="customer_invoice_id" optional="hide" />
+            <field name="note" optional="hide" />
+            <field name="currency_id" invisible="1" />
+        </tree>
+    </field>
+</record>
+
+<record id="school_scholarship_award_schedule_view_form" model="ir.ui.view">
+    <field name="name">school_scholarship_award_schedule - form</field>
+    <field name="model">school_scholarship_award_schedule</field>
+    <field name="arch" type="xml">
+        <form>
+            <sheet>
+                <group name="main" colspan="4" col="2">
+                    <field name="award_id" />
+                    <field name="benefit_id" />
+                    <field name="payment_term_id" />
+                    <field name="date" />
+                    <field name="base_amount" widget="monetary" />
+                    <field name="amount_planned" widget="monetary" />
+                    <field name="amount_planned_manual" />
+                    <field name="amount_realized" widget="monetary" />
+                    <field name="state" />
+                    <field name="payment_term_state" />
+                    <field name="customer_invoice_id" />
+                    <field name="note" />
+                    <field name="currency_id" invisible="1" />
+                </group>
+            </sheet>
+        </form>
+    </field>
+</record>
+</odoo>


### PR DESCRIPTION
## Ringkasan

Menutup pelanggaran `07-views.md` pada `views/school_scholarship_award.xml` yang membuat
`ssi_school_scholarship` berstatus `GAGAL: 3 ERROR` di `verify-module.sh` (gate 12, 13, 15).

- Pindahkan kombinasi amount ringkasan (`amount_awarded`, `amount_realized`,
  `amount_remaining`) dari `header_right` ke `footer_left` (§Kombinasi Amount).
- Ubah `schedule_count`/`realized_count` dari field polos di `header_right` menjadi dua
  smart button (`action_view_schedule`, `action_view_realized_schedule`) di `button_box`
  (Aturan 6), lengkap dengan view standalone baru `school_scholarship_award_schedule.xml`
  (tree + form, tanpa action/menuitem — dibuka hanya lewat smart button) sebagai
  tujuannya.
- Hapus duplikasi `compliance_state` (header_right + page `compliance_renewal`) dan
  `generate_schedule_ok` (invisible di header + `policy_2`) — Aturan 8.
- Tambahkan `class="oe_highlight"` pada tombol `action_generate_schedule` — Aturan 4.
- Saring kolom default tree jadi 3 (`date`, `student_id`, `amount_awarded`), sisanya
  `optional="hide"`.
- Hapus `<group string="Group By">` buatan sendiri di search view; tiga filter dipindah
  ke `//group[@name='group_by']` milik `mixin_transaction_view_search`.
- IK `docs/school_scholarship_award/01-create.md`: tambah 2 entri `## Related Views`
  untuk kedua smart button baru (pola *Nol IK* — pure navigasi, tanpa tour).
- Unit test baru (`tests/test_school_scholarship_award.py`,
  `TestSchoolScholarshipAwardViewActions`) untuk `action_view_schedule` dan
  `action_view_realized_schedule`: dua skenario positif (domain + `res_model`) dan satu
  negatif (`ensure_one` pada recordset 2 award).

## Deviasi dari body issue #85 (dilaporkan, bukan diputuskan sepihak)

Riset lampiran issue sudah menandai kemungkinan ini di bagian "Asumsi yang belum
diverifikasi": setelah verifikasi langsung ke source,

- **`docs/school_scholarship_award/06-generate-schedule.md` TIDAK diubah.** Isinya sama
  sekali tidak menyebut lokasi field/tombol yang berpindah (Flow-nya hanya "klik tombol
  Generate Schedule", Post-Condition-nya tentang tab Schedule) — diverifikasi `grep` tak
  ada satu pun match `amount_*`/`*_count`/`compliance_state`/`header` di berkas itu.
- **`static/tests/tours/school_scholarship_award_tour.js` TIDAK diubah.** Tour ini sama
  sekali tidak menyentuh field yang dipindah (dikonfirmasi baca penuh file 490 baris) —
  satu-satunya interaksi terkait cuma klik tombol "Generate Schedule" via
  `name="action_generate_schedule"`, yang selector-nya tidak berubah oleh penambahan
  `class="oe_highlight"`. `validate-tour.sh` LOLOS 0 ERROR tanpa modifikasi apa pun pada
  tour.

## Kepatuhan

```
#GATE repo=ssi-school-scholarship-85 modules=1 failed=0 skipped=0 precommit=OK mergegate=OK status=OK
#PRECOMMIT repo=ssi-school-scholarship-85 hook=dipasang runs=1 status=OK
#VALIDATOR name=module target=ssi_school_scholarship series=14.0 error=0 warn=0 defer=1 excepted=0 warisan=0 status=OK
#VALIDATOR name=ik target=ssi_school_scholarship series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=tour target=ssi_school_scholarship series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=unit-test target=ssi_school_scholarship series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
```

`defer=1` pada validator `module` adalah utang pra-eksisting (kategori group menumpang
root buatan sendiri) yang tidak terkait Ruang Lingkup item ini.

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0199iwK9DyvFJ5JFFsN73W76