### PR TITLE
[UPD] ssi_school_scholarship_deduction - rapikan tata letak view

### DIFF
--- a/ssi_school_scholarship_deduction/docs/school_scholarship_deduction/01-create.md
+++ b/ssi_school_scholarship_deduction/docs/school_scholarship_deduction/01-create.md
@@ -22,11 +22,12 @@
 2. Click the **New** button. **(14.0: "Create")**
 3. Fill in the required fields:
    - **Award** _(required)_: Select the scholarship award this deduction realizes.
-   - **Journal** _(required)_: Select the accounting journal this document posts to.
-   - **Receivable Account** _(required)_: Select the receivable account this document
-     credits. Must be identical to the Receivable Account of every invoice allocated
-     below, or opening this document is rejected (see `05-approve`).
    - **Date**: Defaults to today's date.
+   - On the **Accounting** tab:
+     - **Journal** _(required)_: Select the accounting journal this document posts to.
+     - **Receivable Account** _(required)_: Select the receivable account this document
+       credits. Must be identical to the Receivable Account of every invoice allocated
+       below, or opening this document is rejected (see `05-approve`).
 4. On the **Lines** tab, add **at least one** line:
    - **Schedule** _(required)_: Select an Award Schedule line, restricted to the
      selected Award's own Schedule. Selecting it fills Description, Product, and Final

--- a/ssi_school_scholarship_deduction/docs/school_scholarship_deduction/05-approve.md
+++ b/ssi_school_scholarship_deduction/docs/school_scholarship_deduction/05-approve.md
@@ -26,7 +26,8 @@
 - The document's status changes to **On Progress**.
 - An `account.move` is created and posted: it credits the document's Receivable Account
   for Amount Total, and debits each Line's own account for its Price Subtotal, carrying
-  that line's Analytic Account.
+  that line's Analytic Account. Its Move and the resulting Receivable Move Line are
+  shown on the **Accounting** tab.
 - The document's Receivable journal item is reconciled against every allocated invoice's
   own receivable journal item — each invoice's Amount Residual drops by its Amount
   Allocated, and an invoice fully covered moves to **Paid**.

--- a/ssi_school_scholarship_deduction/docs/school_scholarship_deduction_recognition/01-create.md
+++ b/ssi_school_scholarship_deduction/docs/school_scholarship_deduction_recognition/01-create.md
@@ -20,15 +20,18 @@
 2. Click the **New** button. **(14.0: "Create")**
 3. Fill in the required fields:
    - **Deduction** _(required)_: Select the deferred deduction document this document
-     releases. Selecting it fills **Journal** from the deduction's own Recognition
-     Journal and **Amount** from the deduction's own Amount Deferred.
-   - **Journal** _(required)_: Defaulted from the selected Deduction; may be overridden.
+     releases. Selecting it fills **Journal** (on the **Accounting** tab) from the
+     deduction's own Recognition Journal and **Amount** from the deduction's own Amount
+     Deferred.
    - **Amount** _(required)_: Defaulted from the selected Deduction's own Amount
      Deferred; may be lowered for a partial (amortized) release. The sum of every Done
      Recognition's Amount on the same Deduction may not exceed that Deduction's own
      Amount Total.
    - **Date**: Defaults to today's date. May not be earlier than the Deduction's own
      Date.
+   - On the **Accounting** tab:
+     - **Journal** _(required)_: Defaulted from the selected Deduction; may be
+       overridden.
 4. Click **Save**.
 
 ## Post-Condition

--- a/ssi_school_scholarship_deduction/docs/school_scholarship_deduction_recognition/05-approve.md
+++ b/ssi_school_scholarship_deduction/docs/school_scholarship_deduction_recognition/05-approve.md
@@ -26,11 +26,12 @@
 
 - The document's status changes directly to **Done** -- this model has no separate
   manual Done step; approval both approves and finalizes the document.
-- An `account.move` is created and posted: for every Line of the linked deduction, it
-  debits that Line's own Final Account and credits its own Deferred Account, each pair
-  for that Line's own Price Subtotal multiplied by Ratio (rounded to the currency's own
-  precision, with the rounding remainder charged to the last pair), carrying that Line's
-  own Analytic Account on both sides.
+- An `account.move` is created and posted, shown as this document's own Move on the
+  **Accounting** tab: for every Line of the linked deduction, it debits that Line's own
+  Final Account and credits its own Deferred Account, each pair for that Line's own
+  Price Subtotal multiplied by Ratio (rounded to the currency's own precision, with the
+  rounding remainder charged to the last pair), carrying that Line's own Analytic
+  Account on both sides.
 - The linked deduction's own **Amount Recognized** increases by this document's own
   Amount, **Amount Deferred** drops by the same, and **Recognition Status** becomes
   **Partially Recognized** or **Recognized** depending on whether any deferred amount

--- a/ssi_school_scholarship_deduction/static/tests/tours/school_scholarship_award_create_due_deduction_tour.js
+++ b/ssi_school_scholarship_deduction/static/tests/tours/school_scholarship_award_create_due_deduction_tour.js
@@ -102,9 +102,21 @@ odoo.define(
 
                 // ── Post-Condition — the newly created Deduction
                 // document is listed in the Scholarship Deductions
-                // list. Waiting for the Award's own name in the Award
-                // column is the only gate here that is guaranteed
-                // false until the wizard's own RPC actually finishes
+                // list, still in Draft
+                // (docs/school_scholarship_award/07-create-due-
+                // deduction.md:41). award_id is optional="hide" on
+                // this tree (odoo-development-backlog#86), so the
+                // Award's own name is not in the DOM; partner_id
+                // (always-visible) renders the Student Contact's name
+                // instead -- school_scholarship_deduction.partner_id
+                // is related="award_id.partner_id", i.e.
+                // student_id.contact_id. The wizard's own action
+                // domain (`[("id", "in", deductions.ids)]`) already
+                // scopes this list to only the Deduction(s) just
+                // created, so this token is unique in the resulting
+                // list regardless of how many other Deductions exist
+                // in the database. The Draft gate is guaranteed false
+                // until the wizard's own RPC actually finishes
                 // (patterns.md §P): no such row exists before this
                 // wizard is run.
                 {
@@ -118,7 +130,8 @@ odoo.define(
                 },
                 {
                     content: "A Deduction for the Award appears in Draft",
-                    trigger: ".o_data_row:contains(TOUR-AWARD-CREATEDEDUCTION-001)",
+                    trigger:
+                        ".o_data_row:contains(TOUR CDD Student Contact):contains(Draft)",
                     run: function () {
                         // Assertion only; do not trigger the default click.
                     },

--- a/ssi_school_scholarship_deduction/static/tests/tours/school_scholarship_deduction_recognition_tour.js
+++ b/ssi_school_scholarship_deduction/static/tests/tours/school_scholarship_deduction_recognition_tour.js
@@ -84,6 +84,13 @@ odoo.define(
                     in_modal: false,
                 },
                 {
+                    // Journal now lives on the Accounting tab
+                    // (07-views.md Aturan 7) -- open it before reading
+                    // the field the Deduction onchange fills.
+                    content: "Open the Accounting tab",
+                    trigger: ".o_notebook .nav-link:contains(Accounting)",
+                },
+                {
                     // Gate: wait for the Deduction onchange's RPC to
                     // fill Journal before saving. `.o_external_button`
                     // (the "open related record" button) is only
@@ -98,7 +105,8 @@ odoo.define(
                     // ssi_school_scholarship_program_tour.js commit
                     // b73daad).
                     content: "Journal reflects the Deduction onchange before saving",
-                    trigger: ".o_field_many2one[name='journal_id'] .o_external_button",
+                    trigger:
+                        ".tab-pane.active .o_field_many2one[name='journal_id'] .o_external_button",
                     run: function () {
                         // Assertion only; do not trigger the default click.
                     },
@@ -180,13 +188,20 @@ odoo.define(
                     },
                 },
                 {
+                    // Move now lives on the Accounting tab (07-views.md
+                    // Aturan 7) -- open it before reading the field.
+                    content: "Open the Accounting tab",
+                    trigger: ".o_notebook .nav-link:contains(Accounting)",
+                },
+                {
                     // A *readonly* many2one in 14.0 (`move_id` is
                     // always `readonly=True`) renders as a bare
                     // `<a class="o_form_uri o_field_widget ...">`, not
                     // `.o_field_many2one` (odoo-development-ui-test
                     // references/selectors.md §8).
                     content: "The Move field is filled",
-                    trigger: ".o_field_widget[name='move_id'].o_form_uri",
+                    trigger:
+                        ".tab-pane.active .o_field_widget[name='move_id'].o_form_uri",
                     run: function () {
                         // Assertion only; do not trigger the default click.
                     },

--- a/ssi_school_scholarship_deduction/static/tests/tours/school_scholarship_deduction_tour.js
+++ b/ssi_school_scholarship_deduction/static/tests/tours/school_scholarship_deduction_tour.js
@@ -66,7 +66,8 @@ odoo.define(
                     },
                 },
 
-                // ── Flow 3 — Fill in Award, Journal, Receivable Account.
+                // ── Flow 3 — Fill in Award, then open the Accounting
+                // tab to fill in Journal and Receivable Account.
                 {
                     content: "Select the Award",
                     trigger: ".o_field_many2one[name='award_id'] input",
@@ -79,8 +80,13 @@ odoo.define(
                     in_modal: false,
                 },
                 {
+                    content: "Open the Accounting tab",
+                    trigger: ".o_notebook .nav-link:contains(Accounting)",
+                },
+                {
                     content: "Select the Journal",
-                    trigger: ".o_field_many2one[name='journal_id'] input",
+                    trigger:
+                        ".tab-pane.active .o_field_many2one[name='journal_id'] input",
                     run: "text TOUR Deduction Sale Journal",
                 },
                 {
@@ -91,7 +97,8 @@ odoo.define(
                 },
                 {
                     content: "Select the Receivable Account",
-                    trigger: ".o_field_many2one[name='receivable_account_id'] input",
+                    trigger:
+                        ".tab-pane.active .o_field_many2one[name='receivable_account_id'] input",
                     run: "text TOUR Deduction Receivable Account",
                 },
                 {
@@ -332,6 +339,13 @@ odoo.define(
                     },
                 },
                 {
+                    // Move and Receivable Move Line now live on the
+                    // Accounting tab (07-views.md Aturan 7) -- open it
+                    // before reading either field.
+                    content: "Open the Accounting tab",
+                    trigger: ".o_notebook .nav-link:contains(Accounting)",
+                },
+                {
                     // A *readonly* many2one in 14.0 (`receivable_move_line_id`
                     // is always `readonly=True`) renders as a bare
                     // `<a class="o_form_uri o_field_widget ...">` -- it
@@ -343,7 +357,7 @@ odoo.define(
                     // references/selectors.md §8, "Field readonly").
                     content: "The Receivable Move Line field is filled",
                     trigger:
-                        ".o_field_widget[name='receivable_move_line_id'].o_form_uri",
+                        ".tab-pane.active .o_field_widget[name='receivable_move_line_id'].o_form_uri",
                     run: function () {
                         // Assertion only; do not trigger the default click.
                     },

--- a/ssi_school_scholarship_deduction/views/school_scholarship_award.xml
+++ b/ssi_school_scholarship_deduction/views/school_scholarship_award.xml
@@ -13,11 +13,11 @@
     <field name="arch" type="xml">
         <data>
             <xpath expr="//header" position="inside">
-                <field name="create_deduction_ok" invisible="1" />
                 <button
                         name="action_open_create_due_deduction_wizard"
                         type="object"
                         string="Create Due Deduction"
+                        class="oe_highlight"
                         attrs="{'invisible': [('create_deduction_ok', '=', False)]}"
                     />
             </xpath>

--- a/ssi_school_scholarship_deduction/views/school_scholarship_deduction.xml
+++ b/ssi_school_scholarship_deduction/views/school_scholarship_deduction.xml
@@ -17,13 +17,13 @@
                 <field name="award_id" />
                 <field name="student_id" />
                 <field name="partner_id" />
-                <group expand="0" string="Group By">
-                    <filter
-                            name="group_by_award_id"
-                            string="Award"
-                            context="{'group_by': 'award_id'}"
-                        />
-                </group>
+            </xpath>
+            <xpath expr="//group[@name='group_by']" position="inside">
+                <filter
+                        name="group_by_award_id"
+                        string="Award"
+                        context="{'group_by': 'award_id'}"
+                    />
             </xpath>
         </data>
     </field>
@@ -45,16 +45,16 @@
             </xpath>
             <xpath expr="//field[@name='company_id']" position="after">
                 <field name="date" />
-                <field name="award_id" />
-                <field name="student_id" />
                 <field name="partner_id" />
                 <field name="amount_total" widget="monetary" />
-                <field name="amount_allocated" widget="monetary" />
-                <field name="amount_unallocated" widget="monetary" />
-                <field name="reconciled" />
-                <field name="recognition_method" />
-                <field name="recognition_state" />
-                <field name="amount_deferred" widget="monetary" />
+                <field name="award_id" optional="hide" />
+                <field name="student_id" optional="hide" />
+                <field name="amount_allocated" widget="monetary" optional="hide" />
+                <field name="amount_unallocated" widget="monetary" optional="hide" />
+                <field name="reconciled" optional="hide" />
+                <field name="recognition_method" optional="hide" />
+                <field name="recognition_state" optional="hide" />
+                <field name="amount_deferred" widget="monetary" optional="hide" />
                 <field name="currency_id" invisible="1" />
             </xpath>
         </data>
@@ -72,24 +72,16 @@
                 <field name="award_id" />
                 <field name="student_id" />
                 <field name="partner_id" />
-                <field name="journal_id" />
-                <field name="receivable_account_id" />
-                <field name="recognition_method" />
-                <field
-                        name="recognition_date"
-                        attrs="{'invisible': [('recognition_method', '=', 'immediate')]}"
-                    />
-                <field
-                        name="deferred_account_id"
-                        attrs="{'invisible': [('recognition_method', '=', 'immediate')]}"
-                    />
-                <field
-                        name="recognition_journal_id"
-                        attrs="{'invisible': [('recognition_method', '=', 'immediate')]}"
-                    />
             </xpath>
             <xpath expr="//group[@name='header_right']" position="inside">
                 <field name="date" />
+                <field name="reconciled" />
+                <field
+                        name="recognition_state"
+                        attrs="{'invisible': [('recognition_method', '=', 'immediate')]}"
+                    />
+            </xpath>
+            <xpath expr="//group[@name='footer_left']" position="inside">
                 <field name="currency_id" invisible="1" />
                 <field name="company_currency_id" invisible="1" />
                 <field
@@ -107,9 +99,8 @@
                         widget="monetary"
                         options="{'currency_field': 'currency_id'}"
                     />
-                <field name="reconciled" />
-                <field name="move_id" />
-                <field name="receivable_move_line_id" />
+            </xpath>
+            <xpath expr="//group[@name='footer_right']" position="inside">
                 <field
                         name="amount_recognized"
                         widget="monetary"
@@ -120,10 +111,6 @@
                         name="amount_deferred"
                         widget="monetary"
                         options="{'currency_field': 'currency_id'}"
-                        attrs="{'invisible': [('recognition_method', '=', 'immediate')]}"
-                    />
-                <field
-                        name="recognition_state"
                         attrs="{'invisible': [('recognition_method', '=', 'immediate')]}"
                     />
             </xpath>
@@ -258,6 +245,34 @@
                             </group>
                         </form>
                     </field>
+                </page>
+                <page name="accounting" string="Accounting">
+                    <group name="accounting_1" colspan="4" col="2">
+                        <field name="journal_id" />
+                        <field name="receivable_account_id" />
+                        <field name="move_id" readonly="1" />
+                        <field name="receivable_move_line_id" readonly="1" />
+                    </group>
+                    <group
+                            name="accounting_2"
+                            string="Deferred Recognition"
+                            colspan="4"
+                            col="2"
+                        >
+                        <field name="recognition_method" />
+                        <field
+                                name="recognition_date"
+                                attrs="{'invisible': [('recognition_method', '=', 'immediate')]}"
+                            />
+                        <field
+                                name="deferred_account_id"
+                                attrs="{'invisible': [('recognition_method', '=', 'immediate')]}"
+                            />
+                        <field
+                                name="recognition_journal_id"
+                                attrs="{'invisible': [('recognition_method', '=', 'immediate')]}"
+                            />
+                    </group>
                 </page>
             </xpath>
         </data>

--- a/ssi_school_scholarship_deduction/views/school_scholarship_deduction_recognition.xml
+++ b/ssi_school_scholarship_deduction/views/school_scholarship_deduction_recognition.xml
@@ -15,13 +15,13 @@
         <data>
             <xpath expr="//search" position="inside">
                 <field name="deduction_id" />
-                <group expand="0" string="Group By">
-                    <filter
-                            name="group_by_deduction_id"
-                            string="Deduction"
-                            context="{'group_by': 'deduction_id'}"
-                        />
-                </group>
+            </xpath>
+            <xpath expr="//group[@name='group_by']" position="inside">
+                <filter
+                        name="group_by_deduction_id"
+                        string="Deduction"
+                        context="{'group_by': 'deduction_id'}"
+                    />
             </xpath>
         </data>
     </field>
@@ -38,8 +38,8 @@
                 <field name="date" />
                 <field name="deduction_id" />
                 <field name="amount" widget="monetary" />
-                <field name="ratio" widget="percentage" />
-                <field name="move_id" />
+                <field name="ratio" widget="percentage" optional="hide" />
+                <field name="move_id" optional="hide" />
                 <field name="currency_id" invisible="1" />
             </xpath>
         </data>
@@ -55,7 +55,6 @@
         <data>
             <xpath expr="//field[@name='user_id']" position="after">
                 <field name="deduction_id" />
-                <field name="journal_id" />
             </xpath>
             <xpath expr="//group[@name='header_right']" position="inside">
                 <field name="date" />
@@ -67,7 +66,6 @@
                         options="{'currency_field': 'currency_id'}"
                     />
                 <field name="ratio" widget="percentage" />
-                <field name="move_id" />
             </xpath>
             <xpath expr="//page[1]" position="before">
                 <page name="recognition_line" string="Recognition Lines">
@@ -94,6 +92,12 @@
                 </page>
                 <page name="note" string="Note">
                     <field name="note" colspan="4" nolabel="1" />
+                </page>
+                <page name="accounting" string="Accounting">
+                    <group name="accounting_1" colspan="4" col="2">
+                        <field name="journal_id" />
+                        <field name="move_id" readonly="1" />
+                    </group>
                 </page>
             </xpath>
         </data>


### PR DESCRIPTION
## Ringkasan

Merapikan tata letak form/tree/search `school_scholarship_deduction` dan
`school_scholarship_deduction_recognition` sesuai `odoo-development` `07-views.md`:

* Kombinasi amount ringkasan (`amount_total`/`amount_allocated`/`amount_unallocated` ke
  `footer_left`; `amount_recognized`/`amount_deferred` ke `footer_right`) dipindah keluar
  dari `header_right` (§Kombinasi Amount).
* Field `account.move` tingkat dokumen (`journal_id`, `receivable_account_id`, `move_id`,
  `receivable_move_line_id`, `recognition_journal_id`, `deferred_account_id`) dikumpulkan
  ke page baru `Accounting` pada kedua form (Aturan 7).
* Deklarasi `create_deduction_ok` yang mubazir dihapus dari view warisan
  `school_scholarship_award` milik modul ini (Aturan 8) -- field sudah tampil di view
  dasar `ssi_school_scholarship`.
* Tombol `action_open_create_due_deduction_wizard` memakai `class="oe_highlight"`
  (Aturan 4).
* Kedua tree dipangkas jadi 3 kolom default-visible, sisanya `optional="hide"`.
* Kedua search view memakai `<group name="group_by">` bawaan mixin, bukan
  `<group string="Group By">` buatan sendiri.
* 5 berkas Instruksi Kerja dan 2 berkas tour pasangan disesuaikan (langkah "Open the
  Accounting tab" ditambahkan sebelum mengisi/membaca field yang pindah).

Tidak ada field, method, atau XML ID yang diubah/dihapus -- murni penempatan di view.

## Deviasi dari issue

`docs/school_scholarship_deduction/06-create-due-recognition.md` dan tour pasangannya
**tidak disentuh**: tour itu hanya berinteraksi dengan wizard (Date + Deductions widget)
dan tidak pernah membuka form `school_scholarship_deduction` maupun menyentuh
`journal_id`/`recognition_journal_id`/`recognition_method` di UI -- field-field itu hanya
muncul di fixture YAML test.

## Verifikasi

* `verify-module.sh ssi_school_scholarship_deduction 14.0` -> `LOLOS: 0 ERROR`
* `validate-ik.sh` -> `LOLOS: 0 ERROR`
* `validate-tour.sh ssi_school_scholarship_deduction 14.0` -> `LOLOS: 0 ERROR`
* `pre-commit-gate.sh` -> `GATE OK`

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0199iwK9DyvFJ5JFFsN73W76