### PR TITLE
[UPD] ssi_school_scholarship_disbursement — rapikan tata letak view

### DIFF
--- a/ssi_school_scholarship_disbursement/docs/school_scholarship_disbursement/01-create.md
+++ b/ssi_school_scholarship_disbursement/docs/school_scholarship_disbursement/01-create.md
@@ -21,15 +21,16 @@
 2. Click the **New** button. **(14.0: "Create")**
 3. Fill in the required fields:
    - **Award** _(required)_: Select the scholarship award this disbursement realizes.
-   - **Journal** _(required)_: Select the accounting journal this document posts to.
-   - **Payable Account** _(required)_: Select the payable account this document credits.
-     Must allow reconciliation, or opening this document is rejected (see `05-approve`).
    - **Payment Method** _(required)_: Select **Cash** or **Bank Transfer**. Defaults to
      Bank Transfer.
    - **Bank Account**: Required when Payment Method is Bank Transfer.
    - **Date**: Defaults to today's date.
    - **Date Due** _(required)_: Must not be earlier than Date.
-4. On the **Lines** tab, add **at least one** line:
+4. On the **Accounting** tab, fill in the required fields:
+   - **Journal** _(required)_: Select the accounting journal this document posts to.
+   - **Payable Account** _(required)_: Select the payable account this document credits.
+     Must allow reconciliation, or opening this document is rejected (see `05-approve`).
+5. On the **Lines** tab, add **at least one** line:
    - **Schedule** _(required)_: Select an Award Schedule line, restricted to the
      selected Award's own Schedule. Selecting it fills Description, Product, and Final
      Account from the Schedule line's Benefit.
@@ -38,7 +39,7 @@
      the Schedule line's Amount Planned multiplied by the Funding line's Percentage.
    - **UoM Quantity**: Left at its default of **1** — Price Unit is also this line's
      total.
-5. Click **Save**.
+6. Click **Save**.
 
 ## Post-Condition
 

--- a/ssi_school_scholarship_disbursement/docs/school_scholarship_disbursement/05-approve.md
+++ b/ssi_school_scholarship_disbursement/docs/school_scholarship_disbursement/05-approve.md
@@ -20,6 +20,7 @@
 2. Open the record to approve.
 3. Click the **Approve** button in the statusbar.
 4. Click **OK** on the confirmation dialog.
+5. Open the **Accounting** tab to see the posting this created.
 
 ## Post-Condition
 
@@ -27,6 +28,9 @@
 - An `account.move` is created and posted: it credits the document's Payable Account for
   Amount Total, and debits each Line's own account for its Price Subtotal, carrying that
   line's Analytic Account.
+- On the **Accounting** tab, **Journal Entry** (`move_id`) now points to that posted
+  `account.move`, and **Payable Move Line** (`payable_move_line_id`) points to its
+  payable line — both are empty before this step.
 - **Amount Residual** equals Amount Total and **Amount Paid** is zero — no
   `account.payment` has been linked yet.
 - Every Cash Schedule line targeted by a Line on this document changes state to

--- a/ssi_school_scholarship_disbursement/static/tests/tours/school_scholarship_award_create_due_disbursement_tour.js
+++ b/ssi_school_scholarship_disbursement/static/tests/tours/school_scholarship_award_create_due_disbursement_tour.js
@@ -103,11 +103,22 @@ odoo.define(
 
                 // ── Post-Condition — the newly created Disbursement
                 // document is listed in the Scholarship Disbursements
-                // list. Waiting for the Award's own name in the Award
-                // column is the only gate here that is guaranteed
-                // false until the wizard's own RPC actually finishes
-                // (patterns.md §P): no such row exists before this
-                // wizard is run.
+                // list. The wizard's own action opens that list scoped
+                // to `domain=[("id", "in", disbursements.ids)]`
+                // (wizards/create_due_scholarship_disbursement.py,
+                // `_open_disbursements`), so every row shown there was
+                // just created by this run -- no row can pre-exist to
+                // collide with the gate below.
+                //
+                // `award_id` is `optional="hide"` in this tree (issue
+                // #87), so the Award's own name -- used by the previous
+                // version of this gate -- is no longer in the DOM at
+                // all. The default-visible columns are `date`,
+                // `partner_id`, `amount_total`; `partner_id` here is
+                // the Award's `student_id.contact_id` ("TOUR CDDB
+                // Student Contact", set up in this file's own
+                // setUpClass), paired with the Draft state badge so the
+                // gate cannot also match a later state of the same row.
                 {
                     content: "Scholarship Disbursements list is displayed",
                     trigger:
@@ -119,7 +130,8 @@ odoo.define(
                 },
                 {
                     content: "A Disbursement for the Award appears in Draft",
-                    trigger: ".o_data_row:contains(TOUR-AWARD-CREATEDISBURSEMENT-001)",
+                    trigger:
+                        ".o_data_row:contains(TOUR CDDB Student Contact):contains(Draft)",
                     run: function () {
                         // Assertion only; do not trigger the default click.
                     },

--- a/ssi_school_scholarship_disbursement/static/tests/tours/school_scholarship_disbursement_tour.js
+++ b/ssi_school_scholarship_disbursement/static/tests/tours/school_scholarship_disbursement_tour.js
@@ -68,8 +68,8 @@ odoo.define(
                     },
                 },
 
-                // ── Flow 3 — Fill in Award, Journal, Payable Account,
-                // Payment Method, Date Due.
+                // ── Flow 3 — Fill in Award, Payment Method, Date, Date
+                // Due, all still in the header.
                 {
                     content: "Select the Award",
                     trigger: ".o_field_many2one[name='award_id'] input",
@@ -79,28 +79,6 @@ odoo.define(
                     content: "Pick the Award from the dropdown",
                     trigger:
                         ".ui-autocomplete .ui-menu-item a:contains(TOUR-DISBURSEMENT-AWARD-CREATE-001)",
-                    in_modal: false,
-                },
-                {
-                    content: "Select the Journal",
-                    trigger: ".o_field_many2one[name='journal_id'] input",
-                    run: "text TOUR Disbursement Cash Journal",
-                },
-                {
-                    content: "Pick the Journal from the dropdown",
-                    trigger:
-                        ".ui-autocomplete .ui-menu-item a:contains(TOUR Disbursement Cash Journal)",
-                    in_modal: false,
-                },
-                {
-                    content: "Select the Payable Account",
-                    trigger: ".o_field_many2one[name='payable_account_id'] input",
-                    run: "text TOUR Disbursement Payable Account",
-                },
-                {
-                    content: "Pick the Payable Account from the dropdown",
-                    trigger:
-                        ".ui-autocomplete .ui-menu-item a:contains(TOUR Disbursement Payable Account)",
                     in_modal: false,
                 },
                 {
@@ -140,7 +118,39 @@ odoo.define(
                     run: "text 08/15/2026",
                 },
 
-                // ── Flow 4 — On the Lines tab, add one line: Schedule
+                // ── Flow 4 — On the Accounting tab, fill in Journal and
+                // Payable Account -- both now live on the "Accounting"
+                // page rather than the header (issue #87).
+                {
+                    content: "Open the Accounting tab",
+                    trigger: ".o_notebook .nav-link:contains(Accounting)",
+                },
+                {
+                    content: "Select the Journal",
+                    trigger:
+                        ".tab-pane.active .o_field_many2one[name='journal_id'] input",
+                    run: "text TOUR Disbursement Cash Journal",
+                },
+                {
+                    content: "Pick the Journal from the dropdown",
+                    trigger:
+                        ".ui-autocomplete .ui-menu-item a:contains(TOUR Disbursement Cash Journal)",
+                    in_modal: false,
+                },
+                {
+                    content: "Select the Payable Account",
+                    trigger:
+                        ".tab-pane.active .o_field_many2one[name='payable_account_id'] input",
+                    run: "text TOUR Disbursement Payable Account",
+                },
+                {
+                    content: "Pick the Payable Account from the dropdown",
+                    trigger:
+                        ".ui-autocomplete .ui-menu-item a:contains(TOUR Disbursement Payable Account)",
+                    in_modal: false,
+                },
+
+                // ── Flow 5 — On the Lines tab, add one line: Schedule
                 // and Funding. Selecting Schedule fills Description,
                 // Product, and Final Account; selecting Funding,
                 // together with Schedule, fills Price Unit.
@@ -203,7 +213,7 @@ odoo.define(
                     run: "click",
                 },
 
-                // ── Flow 5 — Click Save.
+                // ── Flow 6 — Click Save.
                 {
                     content: "Save the record",
                     trigger: ".o_form_button_save",
@@ -330,6 +340,12 @@ odoo.define(
                         // Assertion only; do not trigger the default click.
                     },
                 },
+
+                // Flow 5 — Open the Accounting tab to see the posting.
+                {
+                    content: "Open the Accounting tab",
+                    trigger: ".o_notebook .nav-link:contains(Accounting)",
+                },
                 {
                     // A *readonly* many2one in 14.0 (`payable_move_line_id`
                     // is always `readonly=True`) renders as a bare
@@ -341,7 +357,8 @@ odoo.define(
                     // matches nothing (odoo-development-ui-test
                     // references/selectors.md §8, "Field readonly").
                     content: "The Payable Move Line field is filled",
-                    trigger: ".o_field_widget[name='payable_move_line_id'].o_form_uri",
+                    trigger:
+                        ".tab-pane.active .o_field_widget[name='payable_move_line_id'].o_form_uri",
                     run: function () {
                         // Assertion only; do not trigger the default click.
                     },

--- a/ssi_school_scholarship_disbursement/views/school_scholarship_award.xml
+++ b/ssi_school_scholarship_disbursement/views/school_scholarship_award.xml
@@ -20,6 +20,7 @@
                         name="action_open_create_due_disbursement_wizard"
                         type="object"
                         string="Create Due Disbursement"
+                        class="oe_highlight"
                     />
             </xpath>
         </data>

--- a/ssi_school_scholarship_disbursement/views/school_scholarship_disbursement.xml
+++ b/ssi_school_scholarship_disbursement/views/school_scholarship_disbursement.xml
@@ -17,13 +17,13 @@
                 <field name="award_id" />
                 <field name="student_id" />
                 <field name="partner_id" />
-                <group expand="0" string="Group By">
-                    <filter
-                            name="group_by_award_id"
-                            string="Award"
-                            context="{'group_by': 'award_id'}"
-                        />
-                </group>
+            </xpath>
+            <xpath expr="//group[@name='group_by']" position="inside">
+                <filter
+                        name="group_by_award_id"
+                        string="Award"
+                        context="{'group_by': 'award_id'}"
+                    />
             </xpath>
         </data>
     </field>
@@ -38,14 +38,14 @@
         <data>
             <xpath expr="//field[@name='company_id']" position="after">
                 <field name="date" />
-                <field name="date_due" />
-                <field name="award_id" />
-                <field name="student_id" />
+                <field name="date_due" optional="hide" />
+                <field name="award_id" optional="hide" />
+                <field name="student_id" optional="hide" />
                 <field name="partner_id" />
-                <field name="payment_method" />
+                <field name="payment_method" optional="hide" />
                 <field name="amount_total" widget="monetary" />
-                <field name="amount_paid" widget="monetary" />
-                <field name="amount_residual" widget="monetary" />
+                <field name="amount_paid" widget="monetary" optional="hide" />
+                <field name="amount_residual" widget="monetary" optional="hide" />
                 <field name="currency_id" invisible="1" />
             </xpath>
         </data>
@@ -63,17 +63,17 @@
                 <field name="award_id" />
                 <field name="student_id" />
                 <field name="partner_id" />
-                <field name="journal_id" />
-                <field name="payable_account_id" />
+            </xpath>
+            <xpath expr="//group[@name='header_right']" position="inside">
+                <field name="date" />
+                <field name="date_due" />
                 <field name="payment_method" />
                 <field
                         name="bank_account_id"
                         attrs="{'invisible': [('payment_method', '!=', 'bank_transfer')], 'required': [('payment_method', '=', 'bank_transfer')]}"
                     />
             </xpath>
-            <xpath expr="//group[@name='header_right']" position="inside">
-                <field name="date" />
-                <field name="date_due" />
+            <xpath expr="//group[@name='footer_left']" position="inside">
                 <field name="currency_id" invisible="1" />
                 <field name="company_currency_id" invisible="1" />
                 <field
@@ -91,8 +91,6 @@
                         widget="monetary"
                         options="{'currency_field': 'currency_id'}"
                     />
-                <field name="move_id" />
-                <field name="payable_move_line_id" />
             </xpath>
             <xpath expr="//page[1]" position="before">
                 <page name="line" string="Lines">
@@ -197,6 +195,14 @@
                             </group>
                         </form>
                     </field>
+                </page>
+                <page name="accounting" string="Accounting">
+                    <group name="accounting_1" colspan="4" col="2">
+                        <field name="journal_id" />
+                        <field name="payable_account_id" />
+                        <field name="move_id" readonly="1" />
+                        <field name="payable_move_line_id" readonly="1" />
+                    </group>
                 </page>
             </xpath>
         </data>


### PR DESCRIPTION
## Ringkasan

Merapikan tata letak view `school_scholarship_disbursement` mengikuti standar
`odoo-development` 07-views.md, tanpa mengubah field/method/XML ID yang sudah ada.

- Kombinasi amount ringkasan (`amount_total`, `amount_paid`, `amount_residual`)
  dipindah dari `header_right` ke `footer_left` (§Kombinasi Amount).
- Field `account.move` tingkat dokumen (`journal_id`, `payable_account_id`,
  `move_id`, `payable_move_line_id`) dikumpulkan ke page baru **Accounting**
  (Aturan 7).
- `header_left`/`header_right` diseimbangkan ulang: identitas dokumen di kiri
  (7: 4 bawaan mixin + `award_id`/`student_id`/`partner_id`), waktu & cara
  pembayaran di kanan (4: `date`/`date_due`/`payment_method`/`bank_account_id`).
- Tombol `action_open_create_due_disbursement_wizard` di **form** view memakai
  `class="oe_highlight"` (Aturan 4).
- Tree menyaring kolom default jadi tiga (`date`, `partner_id`, `amount_total`);
  sisanya `optional="hide"`.
- `<group string="Group By">` buatan sendiri di search view dihapus; filter
  `group_by_award_id` dipindah ke `<group name="group_by">` bawaan
  `mixin_transaction_view_search`.

## IK & tour terdampak

- `docs/school_scholarship_disbursement/01-create.md` dan `05-approve.md`
  diperbarui mengikuti pemindahan field.
- `static/tests/tours/school_scholarship_disbursement_tour.js` disesuaikan
  (buka tab Accounting sebelum mengisi Journal/Payable Account, dan sebelum
  membaca Payable Move Line).
- `static/tests/tours/school_scholarship_award_create_due_disbursement_tour.js`
  diperbaiki: `award_id` kini `optional="hide"` di tree disbursement sehingga
  token lama (nama Award) tidak lagi dirender di baris hasil. Diganti dengan
  nama partner (kolom default) + gerbang status Draft. Keunikan token
  struktural terbukti dari `_open_disbursements` di
  `wizards/create_due_scholarship_disbursement.py` yang membuka daftar dengan
  `domain=[("id", "in", disbursements.ids)]` — setiap baris di daftar itu pasti
  hasil run ini sendiri.

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0199iwK9DyvFJ5JFFsN73W76