### PR TITLE
[UPD] ssi_school_scholarship_operating_unit - delta tree/search Operating Unit pada Scholarship Award

### DIFF
--- a/ssi_school_scholarship_operating_unit/views/school_scholarship_award.xml
+++ b/ssi_school_scholarship_operating_unit/views/school_scholarship_award.xml
@@ -4,6 +4,53 @@
      License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
 <odoo>
 
+<record id="school_scholarship_award_view_tree_ou" model="ir.ui.view">
+    <field name="name">school_scholarship_award tree - operating unit</field>
+    <field name="model">school_scholarship_award</field>
+    <field
+            name="inherit_id"
+            ref="ssi_school_scholarship.school_scholarship_award_view_tree"
+        />
+    <field name="arch" type="xml">
+        <data>
+            <xpath expr="//field[@name='company_id']" position="after">
+                <field
+                        name="operating_unit_id"
+                        optional="hide"
+                        groups="operating_unit.group_multi_operating_unit"
+                    />
+            </xpath>
+        </data>
+    </field>
+</record>
+
+<record id="school_scholarship_award_view_search_ou" model="ir.ui.view">
+    <field name="name">school_scholarship_award search - operating unit</field>
+    <field name="model">school_scholarship_award</field>
+    <field
+            name="inherit_id"
+            ref="ssi_school_scholarship.school_scholarship_award_view_search"
+        />
+    <field name="arch" type="xml">
+        <data>
+            <xpath expr="//field[@name='company_id']" position="after">
+                <field
+                        name="operating_unit_id"
+                        groups="operating_unit.group_multi_operating_unit"
+                    />
+            </xpath>
+            <xpath expr="//filter[@name='grp_company']" position="after">
+                <filter
+                        name="grp_ou"
+                        string="Operating Unit"
+                        context="{'group_by': 'operating_unit_id'}"
+                        groups="operating_unit.group_multi_operating_unit"
+                    />
+            </xpath>
+        </data>
+    </field>
+</record>
+
 <record id="school_scholarship_award_view_form_ou" model="ir.ui.view">
     <field name="name">school_scholarship_award form - operating unit</field>
     <field name="model">school_scholarship_award</field>
@@ -16,6 +63,7 @@
             <xpath expr="//field[@name='company_id']" position="after">
                 <field
                         name="operating_unit_id"
+                        optional="hide"
                         groups="operating_unit.group_multi_operating_unit"
                     />
             </xpath>


### PR DESCRIPTION
## Ringkasan

Modul glue `ssi_school_scholarship_operating_unit` sebelumnya hanya menambal **form**
`school_scholarship_award` untuk menampilkan `operating_unit_id`. Delta **tree** dan
**search** belum ada, sehingga pengguna multi-OU tidak bisa melihat kolom Operating Unit
di daftar, mencarinya, atau mengelompokkan dengannya.

PR ini menambahkan:

- `school_scholarship_award_view_tree_ou` — delta tree, `operating_unit_id` dengan
  `optional="hide"`, disisipkan sesudah `//field[@name='company_id']`.
- `school_scholarship_award_view_search_ou` — delta search, field `operating_unit_id`
  serta filter group-by `grp_ou` disisipkan sesudah `//filter[@name='grp_company']`.
- `optional="hide"` ditambahkan pada `operating_unit_id` di record form yang sudah ada
  (`school_scholarship_award_view_form_ou`) — id-nya tidak diubah.

Seluruh node yang disisipkan membawa `groups="operating_unit.group_multi_operating_unit"`.
Tak ada `mode="primary"` yang disetel, dan seluruh jangkar xpath memakai `@name` (bukan
`@string`).

## Ruang Lingkup

Sesuai issue: hanya model transaksi `school_scholarship_award`. Ketiga model master data
modul ini (`school_scholarship_type`, `school_scholarship_program`,
`school_scholarship_funding_source`) sengaja dikecualikan — view tree/search-nya mewarisi
`mixin_master_data_view_tree`/`_view_search` yang tidak memuat `company_id` maupun
`grp_company`, sehingga jangkar kanonik tak tersedia di sana.

## Test

Item ini murni penambahan elemen view aditif — tidak ada field/compute/state baru,
sehingga tidak ada skenario unit test baru (sesuai `## Skenario Uji` issue). Jangkar xpath
yang salah sasaran akan menggagalkan instalasi modul, sehingga CI menjadi gerbangnya.

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J6uRWR5nRbPrzU4BYpENwX