### PR TITLE
[UPD] ssi_school_scholarship_deduction_operating_unit - Tambahkan delta tree dan search Operating Unit

### DIFF
--- a/ssi_school_scholarship_deduction_operating_unit/views/school_scholarship_deduction.xml
+++ b/ssi_school_scholarship_deduction_operating_unit/views/school_scholarship_deduction.xml
@@ -4,6 +4,53 @@
      License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
 <odoo>
 
+<record id="school_scholarship_deduction_view_tree_ou" model="ir.ui.view">
+    <field name="name">school_scholarship_deduction tree - operating unit</field>
+    <field name="model">school_scholarship_deduction</field>
+    <field
+            name="inherit_id"
+            ref="ssi_school_scholarship_deduction.school_scholarship_deduction_view_tree"
+        />
+    <field name="arch" type="xml">
+        <data>
+            <xpath expr="//field[@name='company_id']" position="after">
+                <field
+                        name="operating_unit_id"
+                        optional="hide"
+                        groups="operating_unit.group_multi_operating_unit"
+                    />
+            </xpath>
+        </data>
+    </field>
+</record>
+
+<record id="school_scholarship_deduction_view_search_ou" model="ir.ui.view">
+    <field name="name">school_scholarship_deduction search - operating unit</field>
+    <field name="model">school_scholarship_deduction</field>
+    <field
+            name="inherit_id"
+            ref="ssi_school_scholarship_deduction.school_scholarship_deduction_view_search"
+        />
+    <field name="arch" type="xml">
+        <data>
+            <xpath expr="//field[@name='company_id']" position="after">
+                <field
+                        name="operating_unit_id"
+                        groups="operating_unit.group_multi_operating_unit"
+                    />
+            </xpath>
+            <xpath expr="//filter[@name='grp_company']" position="after">
+                <filter
+                        name="grp_ou"
+                        string="Operating Unit"
+                        context="{'group_by': 'operating_unit_id'}"
+                        groups="operating_unit.group_multi_operating_unit"
+                    />
+            </xpath>
+        </data>
+    </field>
+</record>
+
 <record id="school_scholarship_deduction_view_form_ou" model="ir.ui.view">
     <field name="name">school_scholarship_deduction form - operating unit</field>
     <field name="model">school_scholarship_deduction</field>
@@ -16,6 +63,7 @@
             <xpath expr="//field[@name='company_id']" position="after">
                 <field
                         name="operating_unit_id"
+                        optional="hide"
                         groups="operating_unit.group_multi_operating_unit"
                     />
             </xpath>

--- a/ssi_school_scholarship_deduction_operating_unit/views/school_scholarship_deduction_recognition.xml
+++ b/ssi_school_scholarship_deduction_operating_unit/views/school_scholarship_deduction_recognition.xml
@@ -4,6 +4,57 @@
      License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
 <odoo>
 
+<record id="school_scholarship_deduction_recognition_view_tree_ou" model="ir.ui.view">
+    <field
+            name="name"
+        >school_scholarship_deduction_recognition tree - operating unit</field>
+    <field name="model">school_scholarship_deduction_recognition</field>
+    <field
+            name="inherit_id"
+            ref="ssi_school_scholarship_deduction.school_scholarship_deduction_recognition_view_tree"
+        />
+    <field name="arch" type="xml">
+        <data>
+            <xpath expr="//field[@name='company_id']" position="after">
+                <field
+                        name="operating_unit_id"
+                        optional="hide"
+                        groups="operating_unit.group_multi_operating_unit"
+                    />
+            </xpath>
+        </data>
+    </field>
+</record>
+
+<record id="school_scholarship_deduction_recognition_view_search_ou" model="ir.ui.view">
+    <field
+            name="name"
+        >school_scholarship_deduction_recognition search - operating unit</field>
+    <field name="model">school_scholarship_deduction_recognition</field>
+    <field
+            name="inherit_id"
+            ref="ssi_school_scholarship_deduction.school_scholarship_deduction_recognition_view_search"
+        />
+    <field name="arch" type="xml">
+        <data>
+            <xpath expr="//field[@name='company_id']" position="after">
+                <field
+                        name="operating_unit_id"
+                        groups="operating_unit.group_multi_operating_unit"
+                    />
+            </xpath>
+            <xpath expr="//filter[@name='grp_company']" position="after">
+                <filter
+                        name="grp_ou"
+                        string="Operating Unit"
+                        context="{'group_by': 'operating_unit_id'}"
+                        groups="operating_unit.group_multi_operating_unit"
+                    />
+            </xpath>
+        </data>
+    </field>
+</record>
+
 <record id="school_scholarship_deduction_recognition_view_form_ou" model="ir.ui.view">
     <field
             name="name"
@@ -18,6 +69,7 @@
             <xpath expr="//field[@name='company_id']" position="after">
                 <field
                         name="operating_unit_id"
+                        optional="hide"
                         groups="operating_unit.group_multi_operating_unit"
                     />
             </xpath>


### PR DESCRIPTION
## Ringkasan

Modul glue `ssi_school_scholarship_deduction_operating_unit` sebelumnya hanya menambal
**form**, sehingga `operating_unit_id` tak muncul sebagai kolom daftar, tak bisa dicari,
dan tak bisa dikelompokkan pada kedua model transaksinya. PR ini menambahkan delta
**tree** dan **search** mengikuti pola kanonik yang sudah merged di
`ssi_school_scholarship_operating_unit` (PR #102, issue #96).

Perubahan:

* Tambahkan record `..._view_tree_ou` dan `..._view_search_ou` untuk
  `school_scholarship_deduction` dan `school_scholarship_deduction_recognition`.
* Tambahkan filter group-by `grp_ou` sesudah `grp_company` di tiap search view.
* Tambahkan `optional="hide"` pada `operating_unit_id` di tree dan pada record form
  yang sudah ada.
* `mode` dikosongkan (default `extension`) pada seluruh record delta — bukan
  `primary`.

Referensi: `integrations/operating-unit.md` §View, §Aturan view.

Closes #97

## Test plan

- [x] `assets/verify-module.sh ssi_school_scholarship_deduction_operating_unit 14.0` → `LOLOS: 0 ERROR`
- [x] `pre-commit-gate.sh` → `GATE OK`
- [ ] CI GitHub (menunggu run)

Tidak ada skenario unit test baru — item ini murni penambahan elemen view (lihat
`## Skenario Uji` di issue #97); jangkar xpath yang salah sasaran menggagalkan
instalasi modul, jadi CI sudah menjadi gerbangnya.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J6uRWR5nRbPrzU4BYpENwX