### PR TITLE
[UPD] ssi_school_scholarship_disbursement_operating_unit: delta tree/search OU

### DIFF
--- a/ssi_school_scholarship_disbursement_operating_unit/views/school_scholarship_disbursement.xml
+++ b/ssi_school_scholarship_disbursement_operating_unit/views/school_scholarship_disbursement.xml
@@ -4,6 +4,53 @@
      License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
 <odoo>
 
+<record id="school_scholarship_disbursement_view_tree_ou" model="ir.ui.view">
+    <field name="name">school_scholarship_disbursement tree - operating unit</field>
+    <field name="model">school_scholarship_disbursement</field>
+    <field
+            name="inherit_id"
+            ref="ssi_school_scholarship_disbursement.school_scholarship_disbursement_view_tree"
+        />
+    <field name="arch" type="xml">
+        <data>
+            <xpath expr="//field[@name='company_id']" position="after">
+                <field
+                        name="operating_unit_id"
+                        optional="hide"
+                        groups="operating_unit.group_multi_operating_unit"
+                    />
+            </xpath>
+        </data>
+    </field>
+</record>
+
+<record id="school_scholarship_disbursement_view_search_ou" model="ir.ui.view">
+    <field name="name">school_scholarship_disbursement search - operating unit</field>
+    <field name="model">school_scholarship_disbursement</field>
+    <field
+            name="inherit_id"
+            ref="ssi_school_scholarship_disbursement.school_scholarship_disbursement_view_search"
+        />
+    <field name="arch" type="xml">
+        <data>
+            <xpath expr="//field[@name='company_id']" position="after">
+                <field
+                        name="operating_unit_id"
+                        groups="operating_unit.group_multi_operating_unit"
+                    />
+            </xpath>
+            <xpath expr="//filter[@name='grp_company']" position="after">
+                <filter
+                        name="grp_ou"
+                        string="Operating Unit"
+                        context="{'group_by': 'operating_unit_id'}"
+                        groups="operating_unit.group_multi_operating_unit"
+                    />
+            </xpath>
+        </data>
+    </field>
+</record>
+
 <record id="school_scholarship_disbursement_view_form_ou" model="ir.ui.view">
     <field name="name">school_scholarship_disbursement form - operating unit</field>
     <field name="model">school_scholarship_disbursement</field>
@@ -16,6 +63,7 @@
             <xpath expr="//field[@name='company_id']" position="after">
                 <field
                         name="operating_unit_id"
+                        optional="hide"
                         groups="operating_unit.group_multi_operating_unit"
                     />
             </xpath>


### PR DESCRIPTION
## Ringkasan

Menambahkan record view delta **tree** dan **search** untuk `operating_unit_id` pada
model `school_scholarship_disbursement`, mengikuti pola yang sudah dipakai modul glue
Operating Unit lain di repo ini (`ssi_school_scholarship_operating_unit`,
`ssi_school_scholarship_deduction_operating_unit`). Sebelumnya modul ini hanya
menambal form, sehingga `operating_unit_id` tidak bisa ditampilkan sebagai kolom
daftar, dicari, atau dikelompokkan.

- Record `school_scholarship_disbursement_view_tree_ou` — `operating_unit_id`
  dengan `optional="hide"`, `groups="operating_unit.group_multi_operating_unit"`
- Record `school_scholarship_disbursement_view_search_ou` — `operating_unit_id`
  (tanpa `optional`, tidak bermakna di search) + filter `grp_ou` sesudah `grp_company`
- Record form yang sudah ada (`..._view_form_ou`) ditambahi `optional="hide"` pada
  `operating_unit_id`
- Tak satu pun record menyetel `mode="primary"` (default `extension`)

Closes #98

## Test plan

- [x] `assets/verify-module.sh ssi_school_scholarship_disbursement_operating_unit 14.0` → `LOLOS: 0 ERROR`
- [x] `pre-commit-gate.sh` → `GATE OK`
- [ ] CI GitHub (unit test dijalankan di CI, bukan lokal — sesuai instruksi)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J6uRWR5nRbPrzU4BYpENwX