### PR TITLE
[UPD] ssi_school_scholarship_deduction_operating_unit: lepaskan test kategori dari kategori bersama

### DIFF
--- a/ssi_school_scholarship_deduction_operating_unit/tests/test_data_module_category.yaml
+++ b/ssi_school_scholarship_deduction_operating_unit/tests/test_data_module_category.yaml
@@ -36,35 +36,70 @@ scenarios:
             type: "m2o"
             expected_xml_id: "ssi_school_scholarship_deduction.school_scholarship_deduction_recognition_data_ownership_module_category"
 
-  - name: "No res.groups still points at the shared workflow category"
+  - name:
+      "No res.groups from this module still points at the ssi_school shared workflow
+      category"
     steps:
-      - step: "Search res.groups on the shared workflow category"
-        action: "search"
-        model: "res.groups"
-        domain:
-          [
-            [
-              "category_id",
-              "=",
-              "REF: ssi_school_scholarship.school_scholarship_workflow_module_category",
-            ],
-          ]
-        save_as: "orphan_workflow_groups"
-        expect_count: 0
+      - step: "Get school_scholarship_deduction_operating_unit_group by XML ID"
+        action: "ref"
+        xml_id: "ssi_school_scholarship_deduction_operating_unit.school_scholarship_deduction_operating_unit_group"
+        save_as: "deduction_operating_unit_group"
+      - step:
+          "Get school_scholarship_deduction_recognition_operating_unit_group by XML ID"
+        action: "ref"
+        xml_id: "ssi_school_scholarship_deduction_operating_unit.school_scholarship_deduction_recognition_operating_unit_group"
+        save_as: "deduction_recognition_operating_unit_group"
+      - step:
+          "Assert deduction_operating_unit_group does not point at the shared workflow
+          category"
+        action: "assert"
+        target: "deduction_operating_unit_group"
+        asserts:
+          category_id.id:
+            type: "value"
+            operator: "not_equals"
+            expected: "REF: ssi_school.school_workflow_module_category"
+      - step:
+          "Assert deduction_recognition_operating_unit_group does not point at the
+          shared workflow category"
+        action: "assert"
+        target: "deduction_recognition_operating_unit_group"
+        asserts:
+          category_id.id:
+            type: "value"
+            operator: "not_equals"
+            expected: "REF: ssi_school.school_workflow_module_category"
 
-  - name: "No res.groups still points at the shared data ownership category"
+  - name:
+      "No res.groups from this module still points at the ssi_school shared data
+      ownership category"
     steps:
-      - step: "Search res.groups on the shared data ownership category"
-        action: "search"
-        model: "res.groups"
-        domain:
-          [
-            [
-              "category_id",
-              "=",
-              "REF:
-              ssi_school_scholarship.school_scholarship_data_ownership_module_category",
-            ],
-          ]
-        save_as: "orphan_data_ownership_groups"
-        expect_count: 0
+      - step: "Get school_scholarship_deduction_operating_unit_group by XML ID"
+        action: "ref"
+        xml_id: "ssi_school_scholarship_deduction_operating_unit.school_scholarship_deduction_operating_unit_group"
+        save_as: "deduction_operating_unit_group"
+      - step:
+          "Get school_scholarship_deduction_recognition_operating_unit_group by XML ID"
+        action: "ref"
+        xml_id: "ssi_school_scholarship_deduction_operating_unit.school_scholarship_deduction_recognition_operating_unit_group"
+        save_as: "deduction_recognition_operating_unit_group"
+      - step:
+          "Assert deduction_operating_unit_group does not point at the shared data
+          ownership category"
+        action: "assert"
+        target: "deduction_operating_unit_group"
+        asserts:
+          category_id.id:
+            type: "value"
+            operator: "not_equals"
+            expected: "REF: ssi_school.school_data_ownership_module_category"
+      - step:
+          "Assert deduction_recognition_operating_unit_group does not point at the
+          shared data ownership category"
+        action: "assert"
+        target: "deduction_recognition_operating_unit_group"
+        asserts:
+          category_id.id:
+            type: "value"
+            operator: "not_equals"
+            expected: "REF: ssi_school.school_data_ownership_module_category"


### PR DESCRIPTION
## Ringkasan

`tests/test_data_module_category.yaml` modul ini masih menjaga regresi lewat `REF:` ke
root kategori bersama `ssi_school_scholarship.school_scholarship_workflow_module_category`
dan `…_data_ownership_module_category`. Root itu akan dibuang di issue penutup rantai
(`ssi_school_scholarship` akan berhenti mendefinisikan root kategori sendiri dan memakai
kategori bersama `ssi_school.*` milik `ssi_school`). Karena penghapusan root ada di modul
lain sementara rujukannya ada di modul ini, PR ini melepaskan rujukan itu lebih dulu, dalam
bentuk yang sah baik sebelum maupun sesudah penghapusan.

## Perubahan

- Dua skenario penjaga regresi (`No res.groups still points at the shared workflow
  category`, `No res.groups still points at the shared data ownership category`)
  dipertahankan, bukan dihapus — jangkarnya diganti ke `ssi_school.school_workflow_module_category`
  dan `ssi_school.school_data_ownership_module_category`.
- Karena kategori `ssi_school.*` memang dipakai banyak group dari modul keluarga
  `ssi_school`, assert diubah dari `expect_count: 0` atas populasi kategori (yang akan
  merah karena sebab tak terkait modul ini) menjadi assert `category_id.id` tiap group
  milik modul ini (`school_scholarship_deduction_operating_unit_group`,
  `school_scholarship_deduction_recognition_operating_unit_group`) satu per satu,
  membuktikan tak satu pun menumpang kategori bersama tersebut.
- Tidak ada perubahan pada `security/` modul ini — kedua group sudah menunjuk kategori
  per-model di `ssi_school_scholarship_deduction`.

## Verifikasi

- `assets/verify-tests.sh` → `TESTS OK`
- `assets/validate-unit-test.sh` → `LOLOS: 0 ERROR, 0 peringatan, 0 tertunda`
- `assets/verify-module.sh` → `LOLOS: 0 ERROR, 0 peringatan, 0 tertunda`
- `grep -rn "ssi_school_scholarship\.school_scholarship_\(workflow\|data_ownership\|configurator\)_module_category" ssi_school_scholarship_deduction_operating_unit/` → kosong

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J6uRWR5nRbPrzU4BYpENwX