### PR TITLE
[UPD] ssi_school_scholarship_disbursement_operating_unit - lepaskan test kategori dari kategori bersama ssi_school_scholarship

### DIFF
--- a/ssi_school_scholarship_disbursement_operating_unit/tests/test_data_module_category.yaml
+++ b/ssi_school_scholarship_disbursement_operating_unit/tests/test_data_module_category.yaml
@@ -18,46 +18,40 @@ scenarios:
             type: "value"
             expected: "Operating Unit"
 
-  - name: "No res.groups still points at the shared workflow category"
+  - name:
+      "No res.groups from this module still points at the ssi_school shared workflow
+      category"
     steps:
-      - step: "Search res.groups on the shared workflow category"
-        action: "search"
-        model: "res.groups"
-        domain:
-          [
-            [
-              "category_id",
-              "=",
-              "REF: ssi_school_scholarship.school_scholarship_workflow_module_category",
-            ],
-          ]
-        save_as: "orphan_workflow_groups"
-        expect_count: 0
+      - step: "Get school_scholarship_disbursement_operating_unit_group by XML ID"
+        action: "ref"
+        xml_id: "ssi_school_scholarship_disbursement_operating_unit.school_scholarship_disbursement_operating_unit_group"
+        save_as: "disbursement_operating_unit_group"
+      - step:
+          "Assert disbursement_operating_unit_group does not point at the shared
+          workflow category"
+        action: "assert"
+        target: "disbursement_operating_unit_group"
+        asserts:
+          category_id.id:
+            type: "value"
+            operator: "not_equals"
+            expected: "REF: ssi_school.school_workflow_module_category"
 
   - name:
-      "Only the out-of-scope Deduction Recognition group still points at the shared data
+      "No res.groups from this module still points at the ssi_school shared data
       ownership category"
     steps:
-      - step:
-          "Get the deliberately out-of-scope Deduction Recognition Operating Unit
-          group's id"
+      - step: "Get school_scholarship_disbursement_operating_unit_group by XML ID"
         action: "ref"
-        xml_id: "ssi_school_scholarship_deduction_operating_unit.school_scholarship_deduction_recognition_operating_unit_group"
-        save_as: "recognition_ou_group"
+        xml_id: "ssi_school_scholarship_disbursement_operating_unit.school_scholarship_disbursement_operating_unit_group"
+        save_as: "disbursement_operating_unit_group"
       - step:
-          "Search res.groups on the shared data ownership category, excluding the
-          deliberately out-of-scope Recognition group"
-        action: "search"
-        model: "res.groups"
-        domain:
-          [
-            [
-              "category_id",
-              "=",
-              "REF:
-              ssi_school_scholarship.school_scholarship_data_ownership_module_category",
-            ],
-            ["id", "!=", "REC: recognition_ou_group.id"],
-          ]
-        save_as: "orphan_data_ownership_groups"
-        expect_count: 0
+          "Assert disbursement_operating_unit_group does not point at the shared data
+          ownership category"
+        action: "assert"
+        target: "disbursement_operating_unit_group"
+        asserts:
+          category_id.id:
+            type: "value"
+            operator: "not_equals"
+            expected: "REF: ssi_school.school_data_ownership_module_category"


### PR DESCRIPTION
## Ringkasan

`tests/test_data_module_category.yaml` modul ini masih menjangkarkan dua skenario penjaga
regresi ke kategori bersama `ssi_school_scholarship.school_scholarship_workflow_module_category`
dan `…_data_ownership_module_category` yang akan dibuang oleh issue penutup rantai perapian
kategori modul (`ssi_school_scholarship` masih membuat root kategori sendiri padahal
`ssi_school` sudah menyediakannya). PR ini melepas rujukan tersebut lebih dulu, dalam bentuk
yang sah baik sebelum maupun sesudah root itu dihapus.

- Jangkar kedua skenario diganti ke kategori bersama `ssi_school.school_workflow_module_category`
  dan `ssi_school.school_data_ownership_module_category` (parent baru).
- Bentuk assert-nya berganti dari `search` + `expect_count: 0` menjadi assert per-group
  (`category_id.id != REF: ...`) — kategori `ssi_school.*` dipakai bersama banyak group modul
  keluarga `ssi_school` lain, jadi `expect_count: 0` tidak lagi valid.
- Pengecualian `Deduction Recognition Operating Unit group` dibuang sepenuhnya (bukan
  dialihkan jangkarnya): group itu sudah tidak menumpang kategori bersama apa pun sejak
  `category_id`-nya dipindah ke kategori khusus deduction
  (`ssi_school_scholarship_deduction.school_scholarship_deduction_recognition_data_ownership_module_category`),
  jadi mempertahankan pengecualiannya hanya menyimpan premis basi.

Preseden: pola yang sama persis sudah mendarat untuk modul saudaranya
`ssi_school_scholarship_deduction_operating_unit` di PR #123 (issue #105).

## Verifikasi

- `assets/verify-tests.sh` → `TESTS OK`
- `assets/validate-unit-test.sh` → `LOLOS: 0 ERROR, 0 peringatan, 0 tertunda`
- `assets/verify-module.sh` → `LOLOS: 0 ERROR, 0 peringatan, 0 tertunda`
- `pre-commit-gate.sh` → `GATE OK`

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)