### PR TITLE
[UPD] ssi_school_scholarship_deduction - tuntaskan temuan audit

### DIFF
--- a/ssi_school_scholarship_deduction/models/school_scholarship_deduction.py
+++ b/ssi_school_scholarship_deduction/models/school_scholarship_deduction.py
@@ -60,6 +60,8 @@ class SchoolScholarshipDeduction(models.Model):
 
     # Attributes related to add element on view automatically
     _automatically_insert_view_element = True
+    _automatically_insert_open_policy_fields = False
+    _automatically_insert_open_button = False
 
     _statusbar_visible_label = "draft,confirm,open,done"
     _policy_field_order = [

--- a/ssi_school_scholarship_deduction/security/ir_module_category/school_scholarship_deduction.xml
+++ b/ssi_school_scholarship_deduction/security/ir_module_category/school_scholarship_deduction.xml
@@ -8,10 +8,7 @@
         model="ir.module.category"
     >
     <field name="name">Scholarship Deduction</field>
-    <field
-            name="parent_id"
-            ref="ssi_school_scholarship.school_scholarship_workflow_module_category"
-        />
+    <field name="parent_id" ref="ssi_school.school_workflow_module_category" />
 </record>
 
 <record
@@ -19,9 +16,6 @@
         model="ir.module.category"
     >
     <field name="name">Scholarship Deduction</field>
-    <field
-            name="parent_id"
-            ref="ssi_school_scholarship.school_scholarship_data_ownership_module_category"
-        />
+    <field name="parent_id" ref="ssi_school.school_data_ownership_module_category" />
 </record>
 </odoo>

--- a/ssi_school_scholarship_deduction/security/ir_module_category/school_scholarship_deduction_recognition.xml
+++ b/ssi_school_scholarship_deduction/security/ir_module_category/school_scholarship_deduction_recognition.xml
@@ -8,10 +8,7 @@
         model="ir.module.category"
     >
     <field name="name">Scholarship Deduction Recognition</field>
-    <field
-            name="parent_id"
-            ref="ssi_school_scholarship.school_scholarship_workflow_module_category"
-        />
+    <field name="parent_id" ref="ssi_school.school_workflow_module_category" />
 </record>
 
 <record
@@ -19,9 +16,6 @@
         model="ir.module.category"
     >
     <field name="name">Scholarship Deduction Recognition</field>
-    <field
-            name="parent_id"
-            ref="ssi_school_scholarship.school_scholarship_data_ownership_module_category"
-        />
+    <field name="parent_id" ref="ssi_school.school_data_ownership_module_category" />
 </record>
 </odoo>

--- a/ssi_school_scholarship_deduction/tests/test_data_module_category.yaml
+++ b/ssi_school_scholarship_deduction/tests/test_data_module_category.yaml
@@ -86,9 +86,7 @@ scenarios:
             type: "value"
             expected: "All"
 
-  - name:
-      "New deduction categories are parented under the shared School Scholarship
-      categories"
+  - name: "New deduction categories are parented under the shared School categories"
     steps:
       - step: "Get school_scholarship_deduction_workflow_module_category by XML ID"
         action: "ref"
@@ -105,7 +103,7 @@ scenarios:
         asserts:
           parent_id:
             type: "m2o"
-            expected_xml_id: "ssi_school_scholarship.school_scholarship_workflow_module_category"
+            expected_xml_id: "ssi_school.school_workflow_module_category"
           name:
             type: "value"
             expected: "Scholarship Deduction"
@@ -115,28 +113,22 @@ scenarios:
         asserts:
           parent_id:
             type: "m2o"
-            expected_xml_id: "ssi_school_scholarship.school_scholarship_data_ownership_module_category"
+            expected_xml_id: "ssi_school.school_data_ownership_module_category"
           name:
             type: "value"
             expected: "Scholarship Deduction"
 
-  - name: "No res.groups still points at the shared workflow category"
+  - name: "No res.groups still points directly at the shared workflow category"
     steps:
       - step: "Search res.groups on the shared workflow category"
         action: "search"
         model: "res.groups"
         domain:
-          [
-            [
-              "category_id",
-              "=",
-              "REF: ssi_school_scholarship.school_scholarship_workflow_module_category",
-            ],
-          ]
+          [["category_id", "=", "REF: ssi_school.school_workflow_module_category"]]
         save_as: "orphan_workflow_groups"
         expect_count: 0
 
-  - name: "No res.groups still points at the shared data ownership category"
+  - name: "No res.groups still points directly at the shared data ownership category"
     steps:
       - step: "Search res.groups on the shared data ownership category"
         action: "search"
@@ -146,8 +138,7 @@ scenarios:
             [
               "category_id",
               "=",
-              "REF:
-              ssi_school_scholarship.school_scholarship_data_ownership_module_category",
+              "REF: ssi_school.school_data_ownership_module_category",
             ],
           ]
         save_as: "orphan_data_ownership_groups"

--- a/ssi_school_scholarship_deduction/tests/test_data_school_scholarship_deduction.yaml
+++ b/ssi_school_scholarship_deduction/tests/test_data_school_scholarship_deduction.yaml
@@ -2122,3 +2122,382 @@ scenarios:
         expect_error:
           type: "UserError"
           message_contains: "exceeds its residual"
+
+  - name:
+      "Deduction - open_ok stays False across the auto-transition to open (issue #116)"
+    steps:
+      # ── Shared fixture chain (suffix D3) ─────────────────────────
+      - step: "Create the grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "d3_grade_type"
+        values:
+          name: "D3 Grade Type"
+          code: "D3GT"
+
+      - step: "Create the school"
+        action: "create"
+        model: "school"
+        save_as: "d3_school"
+        values:
+          name: "D3 School"
+          code: "D3SC"
+          grade_type_id: "REC: d3_grade_type.id"
+
+      - step: "Create the academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "d3_academic_year"
+        values:
+          name: "D3 Academic Year"
+          code: "D3AY"
+          date_start: 2026-07-01
+          date_end: 2027-06-30
+
+      - step: "Create the academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "d3_academic_term"
+        values:
+          name: "D3 Term"
+          code: "D3TM"
+          date_start: 2026-07-01
+          date_end: 2026-12-31
+          year_id: "REC: d3_academic_year.id"
+
+      - step: "Create the grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "d3_grade"
+        values:
+          name: "D3 Grade"
+          code: "D3GR"
+          type_id: "REC: d3_grade_type.id"
+
+      - step: "Create the grade class"
+        action: "create"
+        model: "school_grade_class"
+        save_as: "d3_grade_class"
+        values:
+          name: "D3 Class"
+          code: "D3CL"
+          school_id: "REC: d3_school.id"
+          grade_id: "REC: d3_grade.id"
+
+      - step: "Create the student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "d3_contact"
+        values:
+          name: "D3 Contact"
+
+      - step: "Create the student"
+        action: "create"
+        model: "school_student"
+        save_as: "d3_student"
+        values:
+          name: "D3 Student"
+          code: "D3ST"
+          contact_id: "REC: d3_contact.id"
+          school_id: "REC: d3_school.id"
+
+      - step: "Create the enrollment"
+        action: "create"
+        model: "school_enrollment"
+        save_as: "d3_enrollment"
+        values:
+          academic_year_id: "REC: d3_academic_year.id"
+          academic_term_id: "REC: d3_academic_term.id"
+          school_id: "REC: d3_school.id"
+          grade_id: "REC: d3_grade.id"
+          grade_class_id: "REC: d3_grade_class.id"
+          student_id: "REC: d3_student.id"
+
+      - step: "Create the analytic account for the funding source"
+        action: "create"
+        model: "account.analytic.account"
+        save_as: "d3_analytic"
+        values:
+          name: "D3 Analytic"
+
+      - step: "Create the funding source"
+        action: "create"
+        model: "school_scholarship_funding_source"
+        save_as: "d3_funding_source"
+        values:
+          name: "D3 Funding Source"
+          code: "D3FS"
+          analytic_account_id: "REC: d3_analytic.id"
+
+      - step: "Create the product covered by the benefit line"
+        action: "create"
+        model: "product.product"
+        save_as: "d3_product"
+        values:
+          name: "D3 Product"
+          type: "service"
+
+      - step: "Create the sale journal"
+        action: "create"
+        model: "account.journal"
+        save_as: "d3_journal"
+        values:
+          name: "D3 Journal"
+          code: "JD3"
+          type: "sale"
+
+      - step: "Get the account.account.type Income reference"
+        action: "ref"
+        xml_id: "account.data_account_type_revenue"
+        save_as: "account_type_income"
+
+      - step: "Get the account.account.type Receivable reference"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "account_type_receivable"
+
+      - step: "Create the receivable account shared by the invoice and deduction"
+        action: "create"
+        model: "account.account"
+        save_as: "d3_receivable_account"
+        values:
+          name: "D3 Receivable Account"
+          code: "D3RA"
+          user_type_id: "REC: account_type_receivable.id"
+          reconcile: true
+
+      - step: "Create the discount account the deduction line posts to"
+        action: "create"
+        model: "account.account"
+        save_as: "d3_discount_account"
+        values:
+          name: "D3 Discount Account"
+          code: "D3DA"
+          user_type_id: "REC: account_type_income.id"
+          reconcile: false
+
+      - step: "Create the income account the invoice line posts to"
+        action: "create"
+        model: "account.account"
+        save_as: "d3_income_account"
+        values:
+          name: "D3 Income Account"
+          code: "D3IA"
+          user_type_id: "REC: account_type_income.id"
+          reconcile: false
+
+      - step: "Create the customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "d3_invoice_type"
+        values:
+          name: "D3 Invoice Type"
+          code: "/"
+          journal_id: "REC: d3_journal.id"
+          receivable_account_id: "REC: d3_receivable_account.id"
+
+      - step: "Create the scholarship type"
+        action: "create"
+        model: "school_scholarship_type"
+        save_as: "d3_type"
+        values:
+          name: "D3 Type"
+          code: "D3TY"
+          deduction_journal_id: "REC: d3_journal.id"
+          discount_account_id: "REC: d3_discount_account.id"
+
+      - step: "Create the scholarship program"
+        action: "create"
+        model: "school_scholarship_program"
+        save_as: "d3_program"
+        values:
+          name: "D3 Program"
+          code: "D3PRG"
+          type_id: "REC: d3_type.id"
+          school_id: "REC: d3_school.id"
+          academic_year_id: "REC: d3_academic_year.id"
+          funding_source_ids: [[6, 0, ["REC: d3_funding_source.id"]]]
+          deduction_journal_id: "REC: d3_journal.id"
+          discount_account_id: "REC: d3_discount_account.id"
+          scope_ids:
+            - - 0
+              - 0
+              - scope_basis: "product"
+                product_id: "REC: d3_product.id"
+                benefit_type: "cash"
+                computation: "fixed"
+                percentage: 0.0
+                amount_fixed: 100000.0
+
+      - step: "Create the award backing the open_ok fixture"
+        action: "create"
+        model: "school_scholarship_award"
+        save_as: "d3_award"
+        values:
+          program_id: "REC: d3_program.id"
+          student_id: "REC: d3_student.id"
+          enrollment_id: "REC: d3_enrollment.id"
+          date_start: 2026-07-01
+          date_end: 2026-12-31
+          benefit_ids:
+            - - 0
+              - 0
+              - name: "D3 Benefit"
+                product_id: "REC: d3_product.id"
+                benefit_type: "cash"
+                computation: "fixed"
+                amount_fixed: 500000.0
+                periodicity: "one_time"
+          funding_ids:
+            - - 0
+              - 0
+              - funding_source_id: "REC: d3_funding_source.id"
+                percentage: 100.0
+
+      - step: "Find the award's Benefit line"
+        action: "search"
+        model: "school_scholarship_award_benefit"
+        domain: [["award_id", "=", "REC: d3_award.id"]]
+        limit: 1
+        save_as: "d3_benefit"
+
+      - step: "Find the award's Funding line"
+        action: "search"
+        model: "school_scholarship_award_funding"
+        domain: [["award_id", "=", "REC: d3_award.id"]]
+        limit: 1
+        save_as: "d3_funding"
+
+      - step: "Create the Schedule line realizing the Benefit"
+        action: "create"
+        model: "school_scholarship_award_schedule"
+        save_as: "d3_schedule"
+        values:
+          benefit_id: "REC: d3_benefit.id"
+          date: 2026-08-01
+          state: "scheduled"
+
+      - step: "Create an invoice matching the deduction's own amount"
+        action: "create"
+        model: "customer_invoice"
+        save_as: "d3_invoice"
+        values:
+          type_id: "REC: d3_invoice_type.id"
+          partner_id: "REC: d3_contact.id"
+          date: 2026-08-01
+          date_due: 2026-08-15
+          currency_id: "REC: company.currency_id.id"
+          journal_id: "REC: d3_journal.id"
+          receivable_account_id: "REC: d3_receivable_account.id"
+          user_id: "REF: base.user_admin"
+
+      - step: "Add a detail line to the invoice"
+        action: "create"
+        model: "customer_invoice.line"
+        save_as: "d3_invoice_line"
+        values:
+          customer_invoice_id: "REC: d3_invoice.id"
+          name: "D3 Invoice Line"
+          account_id: "REC: d3_income_account.id"
+          uom_quantity: 1
+          price_unit: 500000.0
+
+      - step: "Confirm the invoice"
+        action: "call"
+        target: "d3_invoice"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+        refresh: true
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
+
+      - step: "Approve the invoice, opening it with a 500000 residual"
+        action: "call"
+        target: "d3_invoice"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        refresh: true
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+          amount_residual:
+            type: "value"
+            expected: 500000.0
+
+      - step: "Create the deduction, fully allocated against the invoice"
+        action: "create"
+        model: "school_scholarship_deduction"
+        save_as: "d3_deduction"
+        values:
+          award_id: "REC: d3_award.id"
+          date: 2026-08-05
+          journal_id: "REC: d3_journal.id"
+          receivable_account_id: "REC: d3_receivable_account.id"
+          user_id: "REF: base.user_admin"
+          line_ids:
+            - - 0
+              - 0
+              - schedule_id: "REC: d3_schedule.id"
+                funding_id: "REC: d3_funding.id"
+                final_account_id: "REC: d3_discount_account.id"
+                name: "D3 Deduction Line"
+                uom_quantity: 1
+                amount_allocated: 500000.0
+
+      - step:
+          "Positive: open_ok reads False on the freshly created (draft) deduction,
+          proving the field is still registered and _compute_policy still assigns it --
+          no policy.template_detail grants it (issue #114)"
+        action: "assert"
+        target: "d3_deduction"
+        asserts:
+          state:
+            type: "value"
+            expected: "draft"
+          amount_unallocated:
+            type: "value"
+            expected: 0.0
+          open_ok:
+            type: "value"
+            expected: false
+
+      - step: "Confirm the deduction as admin"
+        action: "call"
+        target: "d3_deduction"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+        refresh: true
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
+
+      - step:
+          "Approve the deduction -- _after_approved_method drives it straight to open
+          with no Start button ever pressed (issue #116)"
+        action: "call"
+        target: "d3_deduction"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        refresh: true
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+      - step:
+          "Negative: open_ok stays False in the open state too, read by base.user_admin
+          -- a member of school_scholarship_deduction_validator_group -- proving the
+          removed Start button was not quietly paired with a policy grant (issue
+          #114/#116)"
+        action: "assert"
+        target: "d3_deduction"
+        as_user: "base.user_admin"
+        refresh: true
+        asserts:
+          open_ok:
+            type: "value"
+            expected: false

--- a/ssi_school_scholarship_deduction/tests/test_data_school_scholarship_deduction.yaml
+++ b/ssi_school_scholarship_deduction/tests/test_data_school_scholarship_deduction.yaml
@@ -2445,6 +2445,11 @@ scenarios:
                 final_account_id: "REC: d3_discount_account.id"
                 name: "D3 Deduction Line"
                 uom_quantity: 1
+                price_unit: 500000.0
+          allocation_ids:
+            - - 0
+              - 0
+              - customer_invoice_id: "REC: d3_invoice.id"
                 amount_allocated: 500000.0
 
       - step:

--- a/ssi_school_scholarship_deduction/views/school_scholarship_deduction.xml
+++ b/ssi_school_scholarship_deduction/views/school_scholarship_deduction.xml
@@ -68,12 +68,10 @@
     <field name="inherit_id" ref="ssi_transaction_mixin.mixin_transaction_view_form" />
     <field name="arch" type="xml">
         <data>
-            <xpath expr="//field[@name='user_id']" position="after">
+            <xpath expr="//group[@name='header_right']" position="inside">
                 <field name="award_id" />
                 <field name="student_id" />
                 <field name="partner_id" />
-            </xpath>
-            <xpath expr="//group[@name='header_right']" position="inside">
                 <field name="date" />
                 <field
                         name="recognition_state"
@@ -259,11 +257,11 @@
                             colspan="4"
                             col="2"
                         >
-                        <field name="recognition_method" />
                         <field
                                 name="recognition_date"
                                 attrs="{'invisible': [('recognition_method', '=', 'immediate')]}"
                             />
+                        <field name="recognition_method" />
                         <field
                                 name="deferred_account_id"
                                 attrs="{'invisible': [('recognition_method', '=', 'immediate')]}"


### PR DESCRIPTION
## Ringkasan

Item konsolidasi empat issue backlog (`#107`, `#111`, `#116`, `#119`) pada modul `ssi_school_scholarship_deduction`, seluruhnya lahir dari sapuan kepatuhan `audit-sweep.sh 14.0 --repo ssi-school-scholarship`:

- **#107** — Kategori `ir.module.category` per-model (Deduction & Recognition, workflow & data ownership) diarahkan ke kategori bersama `ssi_school.*`, bukan lagi ke root buatan `ssi_school_scholarship` (dependency modul ini sudah punya kategori bersama itu). XML ID keempat record tidak berubah, hanya `parent_id`-nya.
- **#111** — Header form `school_scholarship_deduction_view_form` diseimbangkan: `award_id`/`student_id`/`partner_id` dipindah dari `header_left` ke `header_right`, bergabung dengan `date` dan `recognition_state` yang sudah ada di sana (rasio 4 kiri / 5 kanan).
- **#116** — `_automatically_insert_open_policy_fields = False` dan `_automatically_insert_open_button = False` ditambahkan pada `school_scholarship_deduction`, karena transisi `draft -> open` sudah dijalankan sepenuhnya oleh approval (`_after_approved_method = "action_open"`). `open_ok` **tetap terdaftar** di `_get_policy_field()` — hanya penyisipan ke view yang dimatikan.
- **#119** — Urutan `recognition_date` dan `recognition_method` di dalam `<group name="accounting_2" string="Deferred Recognition">` ditukar, sehingga field turunan (`recognition_date`, `attrs` bergantung pada `recognition_method`... koreksi: `recognition_method` di-compute dari `date`/`recognition_date`) tidak lagi tampil sebelum penyetirnya sempat diisi.

`tests/test_data_module_category.yaml` disesuaikan mengikuti XML ID kategori baru (dua assert `parent_id` + dua domain pencarian negatif). Skenario baru ditambahkan ke `tests/test_data_school_scholarship_deduction.yaml` yang membuktikan `open_ok` tetap `False` -- baik di state `draft` maupun setelah dokumen otomatis berpindah ke `open` lewat approval tanpa tombol Start ditekan, dibaca oleh anggota group validator (`base.user_admin`).

Tidak ada nilai, compute, atau transisi state yang berubah. Tidak ada migration script -- seluruh perubahan `parent_id` tetap pada XML ID yang sama (Kelompok A/B `10-migration-script.md` tidak terpicu), dan perubahan atribut class hanya memengaruhi elemen yang disisipkan ke arch view saat runtime.

Closes #107
Closes #111
Closes #116
Closes #119
Closes #120

## Verifikasi

- `verify-module.sh ssi_school_scholarship_deduction 14.0` -> `LOLOS: 0 ERROR, 0 peringatan, 0 tertunda`
- `verify-tests.sh` -> `TESTS OK`
- `validate-unit-test.sh ssi_school_scholarship_deduction 14.0` -> `LOLOS: 0 ERROR, 0 peringatan, 0 tertunda`
- `pre-commit-gate.sh` -> `GATE OK`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J6uRWR5nRbPrzU4BYpENwX