### PR TITLE
[UPD] ssi_school_scholarship_disbursement

### DIFF
--- a/ssi_school_scholarship_disbursement/models/school_scholarship_disbursement.py
+++ b/ssi_school_scholarship_disbursement/models/school_scholarship_disbursement.py
@@ -60,6 +60,8 @@ class SchoolScholarshipDisbursement(models.Model):
 
     # Attributes related to add element on view automatically
     _automatically_insert_view_element = True
+    _automatically_insert_open_policy_fields = False
+    _automatically_insert_open_button = False
 
     _statusbar_visible_label = "draft,confirm,open,done"
     _policy_field_order = [

--- a/ssi_school_scholarship_disbursement/security/ir_module_category/school_scholarship_disbursement.xml
+++ b/ssi_school_scholarship_disbursement/security/ir_module_category/school_scholarship_disbursement.xml
@@ -8,10 +8,7 @@
         model="ir.module.category"
     >
     <field name="name">Scholarship Disbursement</field>
-    <field
-            name="parent_id"
-            ref="ssi_school_scholarship.school_scholarship_workflow_module_category"
-        />
+    <field name="parent_id" ref="ssi_school.school_workflow_module_category" />
 </record>
 
 <record
@@ -19,9 +16,6 @@
         model="ir.module.category"
     >
     <field name="name">Scholarship Disbursement</field>
-    <field
-            name="parent_id"
-            ref="ssi_school_scholarship.school_scholarship_data_ownership_module_category"
-        />
+    <field name="parent_id" ref="ssi_school.school_data_ownership_module_category" />
 </record>
 </odoo>

--- a/ssi_school_scholarship_disbursement/tests/test_data_module_category.yaml
+++ b/ssi_school_scholarship_disbursement/tests/test_data_module_category.yaml
@@ -106,7 +106,7 @@ scenarios:
         asserts:
           parent_id:
             type: "m2o"
-            expected_xml_id: "ssi_school_scholarship.school_scholarship_workflow_module_category"
+            expected_xml_id: "ssi_school.school_workflow_module_category"
           name:
             type: "value"
             expected: "Scholarship Disbursement"
@@ -116,30 +116,24 @@ scenarios:
         asserts:
           parent_id:
             type: "m2o"
-            expected_xml_id: "ssi_school_scholarship.school_scholarship_data_ownership_module_category"
+            expected_xml_id: "ssi_school.school_data_ownership_module_category"
           name:
             type: "value"
             expected: "Scholarship Disbursement"
 
-  - name: "No res.groups still points at the shared workflow category"
+  - name: "No res.groups still points at the ssi_school shared workflow category"
     steps:
-      - step: "Search res.groups on the shared workflow category"
+      - step: "Search res.groups on the ssi_school shared workflow category"
         action: "search"
         model: "res.groups"
         domain:
-          [
-            [
-              "category_id",
-              "=",
-              "REF: ssi_school_scholarship.school_scholarship_workflow_module_category",
-            ],
-          ]
+          [["category_id", "=", "REF: ssi_school.school_workflow_module_category"]]
         save_as: "orphan_workflow_groups"
         expect_count: 0
 
   - name:
-      "Only the out-of-scope Deduction Recognition group still points at the shared data
-      ownership category"
+      "Only the out-of-scope Deduction Recognition group still points at the ssi_school
+      shared data ownership category"
     steps:
       - step:
           "Get the deliberately out-of-scope Deduction Recognition Operating Unit
@@ -148,8 +142,8 @@ scenarios:
         xml_id: "ssi_school_scholarship_deduction_operating_unit.school_scholarship_deduction_recognition_operating_unit_group"
         save_as: "recognition_ou_group"
       - step:
-          "Search res.groups on the shared data ownership category, excluding the
-          deliberately out-of-scope Recognition group"
+          "Search res.groups on the ssi_school shared data ownership category, excluding
+          the deliberately out-of-scope Recognition group"
         action: "search"
         model: "res.groups"
         domain:
@@ -157,8 +151,7 @@ scenarios:
             [
               "category_id",
               "=",
-              "REF:
-              ssi_school_scholarship.school_scholarship_data_ownership_module_category",
+              "REF: ssi_school.school_data_ownership_module_category",
             ],
             ["id", "!=", "REC: recognition_ou_group.id"],
           ]

--- a/ssi_school_scholarship_disbursement/tests/test_data_school_scholarship_disbursement.yaml
+++ b/ssi_school_scholarship_disbursement/tests/test_data_school_scholarship_disbursement.yaml
@@ -329,6 +329,17 @@ scenarios:
             type: "value"
             expected: 500000.0
 
+      - step:
+          "Assert open_ok reads False without error in draft -- open_ok stays registered
+          for mixin.policy's compute even though no button/policy detail can ever set it
+          True"
+        action: "assert"
+        target: "b1_disbursement_single"
+        asserts:
+          open_ok:
+            type: "value"
+            expected: false
+
       - step: "Confirm the single disbursement as admin"
         action: "call"
         target: "b1_disbursement_single"
@@ -362,6 +373,19 @@ scenarios:
           payable_move_line_id:
             type: "value"
             operator: "is_truthy"
+
+      - step:
+          "Assert open_ok is still False in open, read by base.user_admin -- a Validator
+          group member -- proving the button's removal was not quietly paired with a
+          policy.template_detail grant for open_ok"
+        action: "assert"
+        target: "b1_disbursement_single"
+        as_user: "base.user_admin"
+        refresh: true
+        asserts:
+          open_ok:
+            type: "value"
+            expected: false
 
       - step: "Assert Amount Residual equals Amount Total before any payment"
         action: "assert"


### PR DESCRIPTION
## Ringkasan

Tuntaskan dua temuan audit terpisah pada `ssi_school_scholarship_disbursement` yang sama-sama menyentuh model `school_scholarship_disbursement`, dilebur jadi satu issue oleh perencana (issue #121, peleburan dari #108 + #117).

* **Kategori security** — `parent_id` kedua kategori per-model (`school_scholarship_disbursement_workflow_module_category`, `school_scholarship_disbursement_data_ownership_module_category`) diarahkan langsung ke kategori bersama `ssi_school.school_workflow_module_category` / `ssi_school.school_data_ownership_module_category`, bukan lagi menumpang root buatan sendiri `ssi_school_scholarship` yang akan dibersihkan di rantai #113. XML ID kedua record **tidak berubah** — modul lain (`ssi_school_scholarship_disbursement_operating_unit`) merujuknya.
* **Tombol Start & policy `open_ok` mati permanen** — `school_scholarship_disbursement` memakai `_after_approved_method = "action_open"` sehingga transisi ke `open` selalu otomatis, tapi dua flag `_automatically_insert_open_policy_fields`/`_automatically_insert_open_button` belum di-override (default `True`). Akibatnya tombol Start dan baris policy `open_ok` tersisip ke form padahal `open_ok` tak pernah bisa `True`. Kedua flag kini diset `False`. `open_ok` **tetap** terdaftar di `_get_policy_field()` (dengan docstring penjelasnya) — menghapusnya akan melempar `ValueError` saat form dirender.

`tests/test_data_module_category.yaml` disesuaikan agar tetap menguji hal yang sama terhadap `parent_id` baru, dan dua skenario baru ditambahkan pada `tests/test_data_school_scholarship_disbursement.yaml` untuk membuktikan `open_ok` tetap terdaftar & selalu `False` (di draft maupun di `open`, dibaca sebagai anggota group Validator).

Tidak ada migration script — perubahan `parent_id` dimutakhirkan Odoo otomatis lewat update modul biasa (berkas tak ber-`noupdate`), dan perubahan dua atribut class hanya menyentuh elemen yang disisipkan ke arch view saat runtime.

## Kriteria Penerimaan

- [x] `grep -rn "ssi_school_scholarship\.school_scholarship_\(workflow\|data_ownership\)_module_category" ssi_school_scholarship_disbursement/` tidak mengembalikan baris apa pun
- [x] Kedua record kategori tetap ber-XML-ID sama seperti sebelumnya
- [x] `models/school_scholarship_disbursement.py` memuat `_automatically_insert_open_policy_fields = False` dan `_automatically_insert_open_button = False`
- [x] `"open_ok"` masih ada di daftar yang dikembalikan `_get_policy_field()`, dan docstring yang menerangkan alasannya masih utuh
- [x] `_after_approved_method` tetap bernilai `action_open`
- [x] `verify-module.sh` pada modul ini mencetak `LOLOS: 0 ERROR`
- [x] Tidak ada berkas di `migrations/` yang ditambahkan

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J6uRWR5nRbPrzU4BYpENwX